### PR TITLE
Add explicit-control evaluator entrypoint & asynchronous evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 1. Add \"c-slang\" to your PATH
    ```sh
    cd dist
-   npm link
+   yarn link
    ```
 1. To start the repl, run
    ```sh

--- a/src/interpreter/explicitControlEvaluator.ts
+++ b/src/interpreter/explicitControlEvaluator.ts
@@ -1,0 +1,36 @@
+import { type Result, type Value } from './types/evaluationResults';
+import { type CompilationUnitContext } from '../lang/CParser';
+
+/**
+ * Evaluates the abstract syntax tree using an explicit-control evaluator &
+ * returns the result of evaluation asynchronously.
+ *
+ * @param ast The abstract syntax tree to evaluate.
+ */
+export const evaluate = async (
+  ast: CompilationUnitContext
+): Promise<Result> => {
+  return await new Promise(
+    (
+      resolve: (value: Result | PromiseLike<Result>) => void,
+      _reject: (reason?: any) => void
+    ) => {
+      try {
+        const value = interpret(ast);
+        resolve({ status: 'finished', value });
+      } catch (err) {
+        resolve({ status: 'error' });
+      }
+    }
+  );
+};
+
+/**
+ * Interprets the abstract syntax tree using an explicit-control evaluator &
+ * returns the result of evaluation.
+ *
+ * @param ast The abstract syntax tree to evaluate.
+ */
+export const interpret = (ast: CompilationUnitContext): Value => {
+  return undefined;
+};

--- a/src/interpreter/explicitControlEvaluator.ts
+++ b/src/interpreter/explicitControlEvaluator.ts
@@ -1,5 +1,8 @@
 import { type Result, type Value } from './types/evaluationResults';
 import { type CompilationUnitContext } from '../lang/CParser';
+import { Stack } from '../utils/stack';
+import { type ExplicitControlEvaluatorState } from './types/state';
+import { type ParserRuleContext } from 'antlr4ts/ParserRuleContext';
 
 /**
  * Evaluates the abstract syntax tree using an explicit-control evaluator &
@@ -32,5 +35,20 @@ export const evaluate = async (
  * @param ast The abstract syntax tree to evaluate.
  */
 export const interpret = (ast: CompilationUnitContext): Value => {
+  const agenda = new Stack<ParserRuleContext>();
+  agenda.push(ast);
+  const stash = new Stack<Value>();
+  const state: ExplicitControlEvaluatorState = {
+    agenda,
+    stash
+  };
+
+  while (agenda.size() > 0) {
+    const command = agenda.pop();
+    // TODO: Implement the rest of the explicit-control evaluator.
+    console.log(state);
+    console.log(command);
+  }
+
   return undefined;
 };

--- a/src/interpreter/types/evaluationResults.ts
+++ b/src/interpreter/types/evaluationResults.ts
@@ -1,0 +1,12 @@
+export type Value = any;
+
+export interface Finished {
+  status: 'finished';
+  value: Value;
+}
+
+export interface Error {
+  status: 'error';
+}
+
+export type Result = Finished | Error;

--- a/src/interpreter/types/state.ts
+++ b/src/interpreter/types/state.ts
@@ -1,0 +1,9 @@
+import { type Stack } from '../../utils/stack';
+import { type ParserRuleContext } from 'antlr4ts/ParserRuleContext';
+import { type Value } from './evaluationResults';
+
+export interface ExplicitControlEvaluatorState {
+  agenda: Stack<ParserRuleContext>;
+  stash: Stack<Value>;
+  // TODO: Add some notion of an environment.
+}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -1,12 +1,16 @@
 import { CharStreams, CommonTokenStream } from 'antlr4ts';
 import { CLexer } from '../lang/CLexer';
-import { CParser } from '../lang/CParser';
+import { type CompilationUnitContext, CParser } from '../lang/CParser';
 
-export const parse = (text: string): string => {
-  const inputStream = CharStreams.fromString(text);
+/**
+ * Parses C code & returns its abstract syntax tree representation.
+ *
+ * @param code The C code to be parsed.
+ */
+export const parse = (code: string): CompilationUnitContext => {
+  const inputStream = CharStreams.fromString(code);
   const lexer = new CLexer(inputStream);
   const tokens = new CommonTokenStream(lexer);
   const parser = new CParser(tokens);
-  const tree = parser.compilationUnit();
-  return tree.toStringTree(parser);
+  return parser.compilationUnit();
 };

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -1,11 +1,24 @@
 import { start } from 'repl';
-import { parse } from '../parser/parser';
+import { type Context } from 'vm';
+import { run } from '../runner/runner';
+import { type Result } from '../interpreter/types/evaluationResults';
 
 const startRepl = (): void => {
   start({
-    eval: (text, unusedContext, unusedFileName, callback) => {
-      const tree: string = parse(text);
-      callback(null, tree);
+    eval: (
+      replInput: string,
+      _context: Context,
+      _fileName: string,
+      callback: (err: Error | null, result: any) => void
+    ) => {
+      void run(replInput).then((result: Result) => {
+        if (result.status === 'error') {
+          // TODO: Implement error handling.
+          callback(new Error('An error occurred!'), undefined);
+          return;
+        }
+        callback(null, result.value);
+      });
     }
   });
 };

--- a/src/runner/runner.ts
+++ b/src/runner/runner.ts
@@ -1,0 +1,13 @@
+import { type Result } from '../interpreter/types/evaluationResults';
+import { parse } from '../parser/parser';
+import { evaluate } from '../interpreter/explicitControlEvaluator';
+
+/**
+ * Runs the C code asynchronously & returns the result of evaluation.
+ *
+ * @param code The C code to be run.
+ */
+export const run = async (code: string): Promise<Result> => {
+  const ast = parse(code);
+  return await evaluate(ast);
+};

--- a/src/utils/__tests__/stack.ts
+++ b/src/utils/__tests__/stack.ts
@@ -1,0 +1,45 @@
+import { Stack } from '../stack';
+
+describe('Stack', () => {
+  let stack: Stack<number>;
+
+  beforeEach(() => {
+    stack = new Stack();
+  });
+
+  test('should be empty upon initialisation', () => {
+    expect(stack.size()).toBe(0);
+  });
+
+  test('should have a size of 3 after pushing 3 elements onto the stack', () => {
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+    expect(stack.size()).toBe(3);
+  });
+
+  test('should pop elements in reverse order', () => {
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+    expect(stack.pop()).toBe(3);
+    expect(stack.pop()).toBe(2);
+    expect(stack.pop()).toBe(1);
+  });
+
+  test('should peek elements without removing', () => {
+    stack.push(1);
+    expect(stack.peek()).toBe(1);
+    expect(stack.pop()).toBe(1);
+  });
+
+  test('should throw an exception when popping from an empty stack', () => {
+    expect(stack.size()).toBe(0);
+    expect(() => stack.pop()).toThrow('Cannot pop from an empty stack!');
+  });
+
+  test('should throw an exception when peeking from an empty stack', () => {
+    expect(stack.size()).toBe(0);
+    expect(() => stack.peek()).toThrow('Cannot peek from an empty stack!');
+  });
+});

--- a/src/utils/stack.ts
+++ b/src/utils/stack.ts
@@ -1,0 +1,33 @@
+/**
+ * A Last-In-First-Out (LIFO) collection of elements.
+ */
+export class Stack<T> {
+  private readonly elements: T[];
+
+  public constructor() {
+    this.elements = [];
+  }
+
+  public size(): number {
+    return this.elements.length;
+  }
+
+  public push(element: T): void {
+    this.elements.push(element);
+  }
+
+  public pop(): T {
+    const poppedElement = this.elements.pop();
+    if (poppedElement === undefined) {
+      throw new Error('Cannot pop from an empty stack!');
+    }
+    return poppedElement;
+  }
+
+  public peek(): T {
+    if (this.size() === 0) {
+      throw new Error('Cannot peek from an empty stack!');
+    }
+    return this.elements[this.size() - 1];
+  }
+}


### PR DESCRIPTION
I cannot proceed with adding the rest of the explicit-control evaluator skeleton because of the realisation that the output of ANTLR 4 is a parse tree (concrete syntax tree) instead of an abstract syntax tree (unlike in previous versions of ANTLR). As a result, our explicit-control evaluator cannot distinguish between nodes in the concrete syntax tree. This is necessary to determine how to deal with each instruction on the agenda.

We will have to define our own AST which I will do in a separate PR. For now, let's merge whatever structure was added in this PR in. Note that all references to ASTs as of now are incorrect since the ANTLR output is actually a CST - I will correct these in the PR which adds the skeleton of our AST.

Other than that, this PR adds asynchronous evaluation so that the REPL isn't blocked when the program is evaluating.

Also sneaked in a minor edit to the README so that we use Yarn consistently.