### PR TITLE
Implement statements in AST

### DIFF
--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -341,12 +341,19 @@ export class ASTBuilder implements CVisitor<any> {
   }
 
   visitDirectDeclarator(ctx: DirectDeclaratorContext): Identifier {
-    // TODO: Rework this to deal with non-identifiers.
     const identifier = ctx.Identifier();
-    if (identifier === undefined) {
-      throw new Error('Non-identifiers are not supported yet.');
+    if (identifier !== undefined) {
+      return constructIdentifier(identifier);
     }
-    return constructIdentifier(identifier);
+
+    const directDeclarator = ctx.directDeclarator();
+    if (directDeclarator !== undefined) {
+      return this.visitDirectDeclarator(directDeclarator);
+    }
+
+    // TODO: Add other cases in future
+
+    throw new UnreachableCaseError();
   }
 
   visitEnumSpecifier(ctx: EnumSpecifierContext): BaseNode {

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -491,9 +491,25 @@ export class ASTBuilder implements CVisitor<any> {
   }
 
   visitFunctionDefinition(ctx: FunctionDefinitionContext): FunctionDeclaration {
-    // TODO: Implement this.
+    const declarator = ctx.declarator();
+    const compoundStatement = ctx.compoundStatement();
+
+    if (declarator === undefined) {
+      throw new BrokenInvariantError(
+        'Encountered a FunctionDefinition without a declarator.'
+      );
+    }
+
+    if (compoundStatement === undefined) {
+      throw new BrokenInvariantError(
+        'Encountered a FunctionDefinition without a compound statement.'
+      );
+    }
+
     return {
-      type: 'FunctionDeclaration'
+      type: 'FunctionDeclaration',
+      id: this.visitDeclarator(declarator),
+      body: this.visitCompoundStatement(compoundStatement)
     };
   }
 

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -131,7 +131,11 @@ import {
   type VisitTypeSpecifierReturnValue
 } from './astBuilderInternalTypes';
 import { isTypedefNameReturnValue } from './typeGuards';
-import { constructEmptyStatement, constructIdentifier } from './constructors';
+import {
+  constructEmptyStatement,
+  constructIdentifier,
+  constructPlaceholderIdentifier
+} from './constructors';
 
 export class ASTBuilder implements CVisitor<any> {
   visit(tree: ParseTree): BaseNode {
@@ -381,7 +385,8 @@ export class ASTBuilder implements CVisitor<any> {
   }
 
   visitExpression(ctx: ExpressionContext): Expression {
-    throw new Error('Method not implemented.');
+    // TODO: Implement this properly
+    return constructPlaceholderIdentifier('temp');
   }
 
   visitExpressionStatement(

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -393,15 +393,14 @@ export class ASTBuilder implements CVisitor<any> {
     ctx: ExpressionStatementContext
   ): ExpressionOrEmptyStatement {
     const expression = ctx.expression();
-
-    if (expression === undefined) {
-      return constructEmptyStatement();
+    if (expression !== undefined) {
+      return {
+        type: 'ExpressionStatement',
+        expression: this.visitExpression(expression)
+      };
     }
 
-    return {
-      type: 'ExpressionStatement',
-      expression: this.visitExpression(expression)
-    };
+    return constructEmptyStatement();
   }
 
   visitExternalDeclaration(
@@ -690,7 +689,7 @@ export class ASTBuilder implements CVisitor<any> {
       };
     }
 
-    // TODO: Case statement when constant-expression is implemented
+    // TODO: Case statement when visitConstantExpression is implemented
 
     if (defaultToken !== undefined && statement !== undefined) {
       return {

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -11,6 +11,7 @@ import {
   type Identifier,
   type IterationStatement,
   type JumpStatement,
+  type LabeledStatement,
   type Program,
   type SelectionStatement,
   type Statement,
@@ -642,8 +643,35 @@ export class ASTBuilder implements CVisitor<any> {
     throw new UnreachableCaseError();
   }
 
-  visitLabeledStatement(ctx: LabeledStatementContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitLabeledStatement(ctx: LabeledStatementContext): LabeledStatement {
+    const caseToken = ctx.Case();
+    const defaultToken = ctx.Default();
+    const identifier = ctx.Identifier();
+    const statement = ctx.statement();
+
+    if (
+      caseToken === undefined &&
+      defaultToken === undefined &&
+      identifier !== undefined &&
+      statement !== undefined
+    ) {
+      return {
+        type: 'IdentifierStatement',
+        label: constructIdentifier(identifier),
+        body: this.visitStatement(statement)
+      };
+    }
+
+    // TODO: Case statement when constant-expression is implemented
+
+    if (defaultToken !== undefined && statement !== undefined) {
+      return {
+        type: 'DefaultStatement',
+        body: this.visitStatement(statement)
+      };
+    }
+
+    throw new UnreachableCaseError();
   }
 
   visitLogicalAndExpression(ctx: LogicalAndExpressionContext): BaseNode {

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -3,6 +3,7 @@ import {
   type AssignmentExpression,
   type BaseNode,
   type Expression,
+  type ExpressionOrEmptyStatement,
   type ExternalDeclaration,
   type FunctionDeclaration,
   type Identifier,
@@ -357,8 +358,21 @@ export class ASTBuilder implements CVisitor<any> {
     throw new Error('Method not implemented.');
   }
 
-  visitExpressionStatement(ctx: ExpressionStatementContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitExpressionStatement(
+    ctx: ExpressionStatementContext
+  ): ExpressionOrEmptyStatement {
+    const expression = ctx.expression();
+
+    if (expression === undefined) {
+      return {
+        type: 'EmptyStatement'
+      };
+    }
+
+    return {
+      type: 'ExpressionStatement',
+      expression: this.visitExpression(expression)
+    };
   }
 
   visitExternalDeclaration(

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -534,9 +534,9 @@ export class ASTBuilder implements CVisitor<any> {
     const expression = ctx.expression();
     const statement = ctx.statement();
 
-    const doWhileStatement = ctx.Do();
+    const doWhileToken = ctx.Do();
     if (
-      doWhileStatement !== undefined &&
+      doWhileToken !== undefined &&
       expression !== undefined &&
       statement !== undefined
     ) {
@@ -547,9 +547,9 @@ export class ASTBuilder implements CVisitor<any> {
       };
     }
 
-    const whileStatement = ctx.While();
+    const whileToken = ctx.While();
     if (
-      whileStatement !== undefined &&
+      whileToken !== undefined &&
       expression !== undefined &&
       statement !== undefined
     ) {
@@ -560,9 +560,9 @@ export class ASTBuilder implements CVisitor<any> {
       };
     }
 
-    const forStatement = ctx.For();
+    const forToken = ctx.For();
     const forCondition = ctx.forCondition();
-    if (forStatement !== undefined && forCondition !== undefined) {
+    if (forToken !== undefined && forCondition !== undefined) {
       return {
         ...this.visitForCondition(forCondition),
         type: 'ForStatement',
@@ -574,32 +574,32 @@ export class ASTBuilder implements CVisitor<any> {
   }
 
   visitJumpStatement(ctx: JumpStatementContext): JumpStatement {
-    const breakStatement = ctx.Break();
-    if (breakStatement !== undefined) {
+    const breakToken = ctx.Break();
+    if (breakToken !== undefined) {
       return {
         type: 'BreakStatement'
       };
     }
 
-    const continueStatement = ctx.Continue();
-    if (continueStatement !== undefined) {
+    const continueToken = ctx.Continue();
+    if (continueToken !== undefined) {
       return {
         type: 'ContinueStatement'
       };
     }
 
-    const gotoStatement = ctx.Goto();
+    const gotoToken = ctx.Goto();
     const identifier = ctx.Identifier();
-    if (gotoStatement !== undefined && identifier !== undefined) {
+    if (gotoToken !== undefined && identifier !== undefined) {
       return {
         type: 'GotoStatement',
         argument: constructIdentifier(identifier)
       };
     }
 
-    const returnStatement = ctx.Return();
+    const returnToken = ctx.Return();
     const expression = ctx.expression();
-    if (returnStatement !== undefined) {
+    if (returnToken !== undefined) {
       return {
         type: 'ReturnStatement',
         argument:

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -801,7 +801,37 @@ export class ASTBuilder implements CVisitor<any> {
   }
 
   visitStatement(ctx: StatementContext): Statement {
-    throw new Error('Method not implemented.');
+    const labeledStatement = ctx.labeledStatement();
+    if (labeledStatement !== undefined) {
+      return this.visitLabeledStatement(labeledStatement);
+    }
+
+    const compoundStatement = ctx.compoundStatement();
+    if (compoundStatement !== undefined) {
+      return this.visitCompoundStatement(compoundStatement);
+    }
+
+    const expressionStatement = ctx.expressionStatement();
+    if (expressionStatement !== undefined) {
+      return this.visitExpressionStatement(expressionStatement);
+    }
+
+    const selectionStatement = ctx.selectionStatement();
+    if (selectionStatement !== undefined) {
+      return this.visitSelectionStatement(selectionStatement);
+    }
+
+    const iterationStatement = ctx.iterationStatement();
+    if (iterationStatement !== undefined) {
+      return this.visitIterationStatement(iterationStatement);
+    }
+
+    const jumpStatement = ctx.jumpStatement();
+    if (jumpStatement !== undefined) {
+      return this.visitJumpStatement(jumpStatement);
+    }
+
+    throw new UnreachableCaseError();
   }
 
   visitStaticAssertDeclaration(ctx: StaticAssertDeclarationContext): BaseNode {

--- a/src/ast/astBuilderInternalTypes.ts
+++ b/src/ast/astBuilderInternalTypes.ts
@@ -1,5 +1,10 @@
 import { type TypeSpecifier } from './keywordWhitelists/typeSpecifiers';
-import { type Identifier } from './types';
+import {
+  type AssignmentExpression,
+  type Expression,
+  type Identifier,
+  type VariableDeclaration
+} from './types';
 
 export interface BaseReturnValue {
   type: string;
@@ -59,4 +64,11 @@ export interface AlignmentSpecifierReturnValue extends BaseReturnValue {
   type: 'AlignmentSpecifier';
   // TODO: Implement the proper type.
   alignmentSpecifier: unknown;
+}
+
+export interface ForCondition extends BaseReturnValue {
+  type: 'ForCondition';
+  init?: VariableDeclaration | Expression;
+  test?: AssignmentExpression[];
+  update?: AssignmentExpression[];
 }

--- a/src/ast/constructors.ts
+++ b/src/ast/constructors.ts
@@ -1,9 +1,15 @@
 import { type TerminalNode } from 'antlr4ts/tree';
-import { type Identifier } from './types';
+import { type EmptyStatement, type Identifier } from './types';
 
 export const constructIdentifier = (identifier: TerminalNode): Identifier => {
   return {
     type: 'Identifier',
     name: identifier.toString()
+  };
+};
+
+export const constructEmptyStatement = (): EmptyStatement => {
+  return {
+    type: 'EmptyStatement'
   };
 };

--- a/src/ast/constructors.ts
+++ b/src/ast/constructors.ts
@@ -1,0 +1,9 @@
+import { type TerminalNode } from 'antlr4ts/tree';
+import { type Identifier } from './types';
+
+export const constructIdentifier = (identifier: TerminalNode): Identifier => {
+  return {
+    type: 'Identifier',
+    name: identifier.toString()
+  };
+};

--- a/src/ast/constructors.ts
+++ b/src/ast/constructors.ts
@@ -13,3 +13,12 @@ export const constructEmptyStatement = (): EmptyStatement => {
     type: 'EmptyStatement'
   };
 };
+
+export const constructPlaceholderIdentifier = (
+  placeholder: string
+): Identifier => {
+  return {
+    type: 'Identifier',
+    name: placeholder
+  };
+};

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -13,6 +13,7 @@ export interface Program extends BaseNode {
 export type ExternalDeclaration = FunctionDeclaration | VariableDeclaration;
 
 export type Statement =
+  | LabeledStatement
   | BlockOrEmptyStatement
   | ExpressionOrEmptyStatement
   | SelectionStatement
@@ -20,6 +21,19 @@ export type Statement =
   | JumpStatement;
 
 export interface BaseStatement extends BaseNode {}
+
+export type LabeledStatement = IdentifierStatement | DefaultStatement;
+
+export interface IdentifierStatement extends BaseStatement {
+  type: 'IdentifierStatement';
+  label: Identifier;
+  body: Statement;
+}
+
+export interface DefaultStatement extends BaseStatement {
+  type: 'DefaultStatement';
+  body: Statement;
+}
 
 export type BlockOrEmptyStatement = BlockItem[] | EmptyStatement;
 

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -12,7 +12,34 @@ export interface Program extends BaseNode {
 
 export type ExternalDeclaration = FunctionDeclaration | VariableDeclaration;
 
+export type Statement = IterationStatement | JumpStatement;
+
 export interface BaseStatement extends BaseNode {}
+
+export type IterationStatement =
+  | DoWhileStatement
+  | ForStatement
+  | WhileStatement;
+
+export interface DoWhileStatement extends BaseStatement {
+  type: 'DoWhileStatement';
+  test: Expression;
+  body: Statement;
+}
+
+export interface ForStatement extends BaseStatement {
+  type: 'ForStatement';
+  init?: VariableDeclaration | Expression;
+  test?: AssignmentExpression[];
+  update?: AssignmentExpression[];
+  body: Statement;
+}
+
+export interface WhileStatement extends BaseStatement {
+  type: 'WhileStatement';
+  test: Expression;
+  body: Statement;
+}
 
 export type JumpStatement =
   | BreakStatement

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -12,9 +12,24 @@ export interface Program extends BaseNode {
 
 export type ExternalDeclaration = FunctionDeclaration | VariableDeclaration;
 
-export type Statement = SelectionStatement | IterationStatement | JumpStatement;
+export type Statement =
+  | ExpressionOrEmptyStatement
+  | SelectionStatement
+  | IterationStatement
+  | JumpStatement;
 
 export interface BaseStatement extends BaseNode {}
+
+export type ExpressionOrEmptyStatement = EmptyStatement | ExpressionStatement;
+
+export interface EmptyStatement extends BaseStatement {
+  type: 'EmptyStatement';
+}
+
+export interface ExpressionStatement extends BaseStatement {
+  type: 'ExpressionStatement';
+  expression: Expression;
+}
 
 export type SelectionStatement = IfStatement | SwitchStatement;
 

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -13,12 +13,17 @@ export interface Program extends BaseNode {
 export type ExternalDeclaration = FunctionDeclaration | VariableDeclaration;
 
 export type Statement =
+  | BlockOrEmptyStatement
   | ExpressionOrEmptyStatement
   | SelectionStatement
   | IterationStatement
   | JumpStatement;
 
 export interface BaseStatement extends BaseNode {}
+
+export type BlockOrEmptyStatement = BlockItem[] | EmptyStatement;
+
+export type BlockItem = VariableDeclaration | Statement;
 
 export type ExpressionOrEmptyStatement = EmptyStatement | ExpressionStatement;
 

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -12,9 +12,24 @@ export interface Program extends BaseNode {
 
 export type ExternalDeclaration = FunctionDeclaration | VariableDeclaration;
 
-export type Statement = IterationStatement | JumpStatement;
+export type Statement = SelectionStatement | IterationStatement | JumpStatement;
 
 export interface BaseStatement extends BaseNode {}
+
+export type SelectionStatement = IfStatement | SwitchStatement;
+
+export interface IfStatement extends BaseStatement {
+  type: 'IfStatement';
+  test: Expression;
+  consequent: Statement;
+  alternate?: Statement;
+}
+
+export interface SwitchStatement extends BaseStatement {
+  type: 'SwitchStatement';
+  discriminant: Expression;
+  body: Statement;
+}
 
 export type IterationStatement =
   | DoWhileStatement

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -14,6 +14,30 @@ export type ExternalDeclaration = FunctionDeclaration | VariableDeclaration;
 
 export interface BaseStatement extends BaseNode {}
 
+export type JumpStatement =
+  | BreakStatement
+  | ContinueStatement
+  | GotoStatement
+  | ReturnStatement;
+
+export interface BreakStatement extends BaseStatement {
+  type: 'BreakStatement';
+}
+
+export interface ContinueStatement extends BaseStatement {
+  type: 'ContinueStatement';
+}
+
+export interface GotoStatement extends BaseStatement {
+  type: 'GotoStatement';
+  argument: Identifier;
+}
+
+export interface ReturnStatement extends BaseStatement {
+  type: 'ReturnStatement';
+  argument?: Expression;
+}
+
 export type Expression = AssignmentExpression | Identifier;
 
 export interface BaseExpression extends BaseNode {}

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -146,9 +146,11 @@ export type AssignmentOperator =
 
 export interface BaseDeclaration extends BaseStatement {}
 
-// TODO: Implement this.
 export interface FunctionDeclaration extends BaseDeclaration {
   type: 'FunctionDeclaration';
+  // TODO: Add declaration specifiers
+  id: Identifier;
+  body: BlockOrEmptyStatement;
 }
 
 export interface VariableDeclaration extends BaseDeclaration {

--- a/src/parser/__tests__/statements/jumpStatement.ts
+++ b/src/parser/__tests__/statements/jumpStatement.ts
@@ -1,0 +1,54 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('return statement', () => {
+  it('handles argument', () => {
+    const code = 'int main() { return 0; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ReturnStatement',
+              argument: {
+                type: 'Identifier',
+                name: 'temp'
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  it('handles no argument', () => {
+    const code = 'int f() { return; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'f'
+          },
+          body: [
+            {
+              type: 'ReturnStatement'
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/statements/jumpStatement.ts
+++ b/src/parser/__tests__/statements/jumpStatement.ts
@@ -52,3 +52,46 @@ describe('return statement', () => {
     expect(ast).toEqual(expectedAst);
   });
 });
+
+describe('goto statement', () => {
+  it('goes to identifier', () => {
+    const code = 'int main() { x : return 0; goto x; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'IdentifierStatement',
+              label: {
+                type: 'Identifier',
+                name: 'x'
+              },
+              body: {
+                type: 'ReturnStatement',
+                argument: {
+                  type: 'Identifier',
+                  name: 'temp'
+                }
+              }
+            },
+            {
+              type: 'GotoStatement',
+              argument: {
+                type: 'Identifier',
+                name: 'x'
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});


### PR DESCRIPTION
Implemented the visiting of all statements in AST except:
- switch case statement under `visitLabeledStatement`. This is because it needs to `visitConstantExpression`.

Added support for more cases for these, so that statements can be tested:
- `visitFunctionDefinition`
- `visitDirectDeclarator`

Returned a placeholder value for `visitExpression` so that statements can be tested briefly.

Not sure about `visitForCondition`, whether the `firstForExpression` and `secondForExpression` things are correct. But it's a bit hard to test now because `visitAssignmentExpression` is not implemented yet. It should be easy to find and correct mistakes later anyway.