### PR TITLE
Add AST support for binary expressions, logical expressions, identifiers/constants, expression sequences

### DIFF
--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -1,6 +1,5 @@
 import { type CVisitor } from '../lang/CVisitor';
 import {
-  type AssignmentExpression,
   type BaseNode,
   type BlockItem,
   type BlockOrEmptyStatement,
@@ -158,8 +157,16 @@ export class ASTBuilder implements CVisitor<any> {
     throw new Error('Method not implemented.');
   }
 
-  visitAdditiveExpression(ctx: AdditiveExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitAdditiveExpression(ctx: AdditiveExpressionContext): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const multiplicativeExpression = ctx.multiplicativeExpression(0);
+    if (multiplicativeExpression !== undefined) {
+      return this.visitMultiplicativeExpression(multiplicativeExpression);
+    }
+
+    // TODO: Deal with additive expressions.
+
+    throw new UnreachableCaseError();
   }
 
   visitAlignmentSpecifier(
@@ -168,18 +175,31 @@ export class ASTBuilder implements CVisitor<any> {
     throw new Error('Method not implemented.');
   }
 
-  visitAndExpression(ctx: AndExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitAndExpression(ctx: AndExpressionContext): Expression {
+    const equalityExpression = ctx.equalityExpression(0);
+    if (equalityExpression !== undefined) {
+      return this.visitEqualityExpression(equalityExpression);
+    }
+
+    // TODO: Deal with AND expressions.
+
+    throw new UnreachableCaseError();
   }
 
   visitArgumentExpressionList(ctx: ArgumentExpressionListContext): BaseNode {
     throw new Error('Method not implemented.');
   }
 
-  visitAssignmentExpression(
-    ctx: AssignmentExpressionContext
-  ): AssignmentExpression {
-    throw new Error('Method not implemented.');
+  visitAssignmentExpression(ctx: AssignmentExpressionContext): Expression {
+    const conditionalExpression = ctx.conditionalExpression();
+    if (conditionalExpression !== undefined) {
+      return this.visitConditionalExpression(conditionalExpression);
+    }
+
+    // TODO: Deal with assignments.
+    // TODO: Deal with number sequence.
+
+    throw new UnreachableCaseError();
   }
 
   visitAssignmentOperator(ctx: AssignmentOperatorContext): BaseNode {
@@ -209,8 +229,16 @@ export class ASTBuilder implements CVisitor<any> {
     return blockItems.map(this.visitBlockItem, this);
   }
 
-  visitCastExpression(ctx: CastExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitCastExpression(ctx: CastExpressionContext): Expression {
+    const unaryExpression = ctx.unaryExpression();
+    if (unaryExpression !== undefined) {
+      return this.visitUnaryExpression(unaryExpression);
+    }
+
+    // TODO: Deal with type casting.
+    // TODO: Deal with number sequence.
+
+    throw new UnreachableCaseError();
   }
 
   visitCompilationUnit(ctx: CompilationUnitContext): Program {
@@ -233,8 +261,15 @@ export class ASTBuilder implements CVisitor<any> {
     return constructEmptyStatement();
   }
 
-  visitConditionalExpression(ctx: ConditionalExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitConditionalExpression(ctx: ConditionalExpressionContext): Expression {
+    const logicalOrExpression = ctx.logicalOrExpression();
+    if (logicalOrExpression !== undefined) {
+      return this.visitLogicalOrExpression(logicalOrExpression);
+    }
+
+    // TODO: Deal with conditionals.
+
+    throw new UnreachableCaseError();
   }
 
   visitConstantExpression(ctx: ConstantExpressionContext): BaseNode {
@@ -376,12 +411,28 @@ export class ASTBuilder implements CVisitor<any> {
     throw new Error('Method not implemented.');
   }
 
-  visitEqualityExpression(ctx: EqualityExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitEqualityExpression(ctx: EqualityExpressionContext): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const relationalExpression = ctx.relationalExpression(0);
+    if (relationalExpression !== undefined) {
+      return this.visitRelationalExpression(relationalExpression);
+    }
+
+    // TODO: Deal with equality expressions.
+
+    throw new UnreachableCaseError();
   }
 
-  visitExclusiveOrExpression(ctx: ExclusiveOrExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitExclusiveOrExpression(ctx: ExclusiveOrExpressionContext): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const andExpression = ctx.andExpression(0);
+    if (andExpression !== undefined) {
+      return this.visitAndExpression(andExpression);
+    }
+
+    // TODO: Deal with exclusive OR operations.
+
+    throw new UnreachableCaseError();
   }
 
   visitExpression(ctx: ExpressionContext): Expression {
@@ -496,7 +547,7 @@ export class ASTBuilder implements CVisitor<any> {
     };
   }
 
-  visitForExpression(ctx: ForExpressionContext): AssignmentExpression[] {
+  visitForExpression(ctx: ForExpressionContext): Expression[] {
     const assignmentExpressions = ctx.assignmentExpression();
     return assignmentExpressions.map(this.visitAssignmentExpression, this);
   }
@@ -562,15 +613,29 @@ export class ASTBuilder implements CVisitor<any> {
     throw new Error('Method not implemented.');
   }
 
-  visitInclusiveOrExpression(ctx: InclusiveOrExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitInclusiveOrExpression(ctx: InclusiveOrExpressionContext): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const exclusiveOrExpression = ctx.exclusiveOrExpression(0);
+    if (exclusiveOrExpression !== undefined) {
+      return this.visitExclusiveOrExpression(exclusiveOrExpression);
+    }
+
+    // TODO: Deal with inclusive OR operations.
+
+    throw new UnreachableCaseError();
   }
 
   visitInitDeclarator(ctx: InitDeclaratorContext): VariableDeclarator {
-    // TODO: Implement initial value.
+    const initializer = ctx.initializer();
+    const initialValue =
+      initializer === undefined
+        ? undefined
+        : this.visitInitializer(initializer);
+
     return {
       type: 'VariableDeclarator',
-      id: this.visitDeclarator(ctx.declarator())
+      id: this.visitDeclarator(ctx.declarator()),
+      initialValue
     };
   }
 
@@ -580,8 +645,15 @@ export class ASTBuilder implements CVisitor<any> {
     return ctx.initDeclarator().map(this.visitInitDeclarator, this);
   }
 
-  visitInitializer(ctx: InitializerContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitInitializer(ctx: InitializerContext): Expression {
+    const assignmentExpression = ctx.assignmentExpression();
+    if (assignmentExpression !== undefined) {
+      return this.visitAssignmentExpression(assignmentExpression);
+    }
+
+    // TODO: Deal with initializer list.
+
+    throw new UnreachableCaseError();
   }
 
   visitInitializerList(ctx: InitializerListContext): BaseNode {
@@ -701,18 +773,42 @@ export class ASTBuilder implements CVisitor<any> {
     throw new UnreachableCaseError();
   }
 
-  visitLogicalAndExpression(ctx: LogicalAndExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitLogicalAndExpression(ctx: LogicalAndExpressionContext): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const inclusiveOrExpression = ctx.inclusiveOrExpression(0);
+    if (inclusiveOrExpression !== undefined) {
+      return this.visitInclusiveOrExpression(inclusiveOrExpression);
+    }
+
+    // TODO: Deal with logical AND operations.
+
+    throw new UnreachableCaseError();
   }
 
-  visitLogicalOrExpression(ctx: LogicalOrExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitLogicalOrExpression(ctx: LogicalOrExpressionContext): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const logicalAndExpression = ctx.logicalAndExpression(0);
+    if (logicalAndExpression !== undefined) {
+      return this.visitLogicalAndExpression(logicalAndExpression);
+    }
+
+    // TODO: Deal with logical OR operations.
+
+    throw new UnreachableCaseError();
   }
 
   visitMultiplicativeExpression(
     ctx: MultiplicativeExpressionContext
-  ): BaseNode {
-    throw new Error('Method not implemented.');
+  ): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const castExpression = ctx.castExpression(0);
+    if (castExpression !== undefined) {
+      return this.visitCastExpression(castExpression);
+    }
+
+    // TODO: Deal with multiplicative expressions.
+
+    throw new UnreachableCaseError();
   }
 
   visitNestedParenthesesBlock(ctx: NestedParenthesesBlockContext): BaseNode {
@@ -735,16 +831,38 @@ export class ASTBuilder implements CVisitor<any> {
     throw new Error('Method not implemented.');
   }
 
-  visitPostfixExpression(ctx: PostfixExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitPostfixExpression(ctx: PostfixExpressionContext): Expression {
+    const primaryExpression = ctx.primaryExpression();
+    if (primaryExpression !== undefined) {
+      return this.visitPrimaryExpression(primaryExpression);
+    }
+
+    // TODO: Deal with everything else.
+
+    throw new UnreachableCaseError();
   }
 
-  visitPrimaryExpression(ctx: PrimaryExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitPrimaryExpression(ctx: PrimaryExpressionContext): Expression {
+    const identifier = ctx.Identifier();
+    if (identifier !== undefined) {
+      return constructIdentifier(identifier);
+    }
+
+    // TODO: Deal with everything else.
+
+    throw new UnreachableCaseError();
   }
 
-  visitRelationalExpression(ctx: RelationalExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitRelationalExpression(ctx: RelationalExpressionContext): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const shiftExpression = ctx.shiftExpression(0);
+    if (shiftExpression !== undefined) {
+      return this.visitShiftExpression(shiftExpression);
+    }
+
+    // TODO: Deal with relational expressions.
+
+    throw new UnreachableCaseError();
   }
 
   visitSelectionStatement(ctx: SelectionStatementContext): SelectionStatement {
@@ -796,8 +914,16 @@ export class ASTBuilder implements CVisitor<any> {
     throw new UnreachableCaseError();
   }
 
-  visitShiftExpression(ctx: ShiftExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitShiftExpression(ctx: ShiftExpressionContext): Expression {
+    // TODO: Temporarily hardcoded to make use of the first expression.
+    const additiveExpression = ctx.additiveExpression(0);
+    if (additiveExpression !== undefined) {
+      return this.visitAdditiveExpression(additiveExpression);
+    }
+
+    // TODO: Deal with shift expressions.
+
+    throw new UnreachableCaseError();
   }
 
   visitSpecifierQualifierList(ctx: SpecifierQualifierListContext): BaseNode {
@@ -984,8 +1110,15 @@ export class ASTBuilder implements CVisitor<any> {
     return constructIdentifier(identifier);
   }
 
-  visitUnaryExpression(ctx: UnaryExpressionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitUnaryExpression(ctx: UnaryExpressionContext): Expression {
+    const postfixExpression = ctx.postfixExpression();
+    if (postfixExpression !== undefined) {
+      return this.visitPostfixExpression(postfixExpression);
+    }
+
+    // TODO: Deal with everything else.
+
+    throw new UnreachableCaseError();
   }
 
   visitUnaryOperator(ctx: UnaryOperatorContext): BaseNode {

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -889,6 +889,13 @@ export class ASTBuilder implements CVisitor<any> {
       throw new UnsupportedKeywordError('__extension__');
     }
 
+    if (
+      ctx.childCount > 0 &&
+      ctx.getChild(0).toStringTree() === '__builtin_va_arg'
+    ) {
+      throw new UnsupportedKeywordError('__builtin_va_arg');
+    }
+
     // TODO: Deal with everything else.
 
     throw new UnreachableCaseError();

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -877,6 +877,8 @@ export class ASTBuilder implements CVisitor<any> {
       return constructStringLiteral(stringLiterals[0]);
     }
 
+    // TODO: Deal with expressions in brackets.
+
     const genericSelection = ctx.genericSelection();
     if (genericSelection !== undefined) {
       return this.visitGenericSelection(genericSelection);
@@ -896,7 +898,12 @@ export class ASTBuilder implements CVisitor<any> {
       throw new UnsupportedKeywordError('__builtin_va_arg');
     }
 
-    // TODO: Deal with everything else.
+    if (
+      ctx.childCount > 0 &&
+      ctx.getChild(0).toStringTree() === '__builtin_offsetof'
+    ) {
+      throw new UnsupportedKeywordError('__builtin_offsetof');
+    }
 
     throw new UnreachableCaseError();
   }

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -619,8 +619,8 @@ export class ASTBuilder implements CVisitor<any> {
     throw new Error('Method not implemented.');
   }
 
-  visitGenericSelection(ctx: GenericSelectionContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitGenericSelection(ctx: GenericSelectionContext): Expression {
+    throw new UnsupportedKeywordError('_Generic');
   }
 
   visitIdentifierList(ctx: IdentifierListContext): BaseNode {
@@ -875,6 +875,11 @@ export class ASTBuilder implements CVisitor<any> {
         );
       }
       return constructStringLiteral(stringLiterals[0]);
+    }
+
+    const genericSelection = ctx.genericSelection();
+    if (genericSelection !== undefined) {
+      return this.visitGenericSelection(genericSelection);
     }
 
     // TODO: Deal with everything else.

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -943,15 +943,37 @@ export class ASTBuilder implements CVisitor<any> {
   }
 
   visitRelationalExpression(ctx: RelationalExpressionContext): Expression {
-    // TODO: Temporarily hardcoded to make use of the first expression.
-    const shiftExpression = ctx.shiftExpression(0);
-    if (shiftExpression !== undefined) {
-      return this.visitShiftExpression(shiftExpression);
+    const children = ctx.children;
+    if (children === undefined) {
+      throw new BrokenInvariantError(
+        'Encountered a RelationalExpression with no child nodes.'
+      );
     }
 
-    // TODO: Deal with relational expressions.
-
-    throw new UnreachableCaseError();
+    let leftExpression = this.visitShiftExpression(ctx.shiftExpression(0));
+    for (let i = 1; i * 2 < children.length; i++) {
+      const operator = children[i * 2 - 1].toStringTree();
+      if (
+        !(
+          operator === '<' ||
+          operator === '>' ||
+          operator === '<=' ||
+          operator === '>='
+        )
+      ) {
+        throw new BrokenInvariantError(
+          `Encountered an unexpected operator in RelationalExpression: '${operator}'`
+        );
+      }
+      const rightExpression = this.visitShiftExpression(ctx.shiftExpression(i));
+      leftExpression = {
+        type: 'BinaryExpression',
+        operator,
+        left: leftExpression,
+        right: rightExpression
+      };
+    }
+    return leftExpression;
   }
 
   visitSelectionStatement(ctx: SelectionStatementContext): SelectionStatement {

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -882,6 +882,13 @@ export class ASTBuilder implements CVisitor<any> {
       return this.visitGenericSelection(genericSelection);
     }
 
+    if (
+      ctx.childCount > 0 &&
+      ctx.getChild(0).toStringTree() === '__extension__'
+    ) {
+      throw new UnsupportedKeywordError('__extension__');
+    }
+
     // TODO: Deal with everything else.
 
     throw new UnreachableCaseError();

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -612,11 +612,11 @@ export class ASTBuilder implements CVisitor<any> {
   }
 
   visitGenericAssocList(ctx: GenericAssocListContext): BaseNode {
-    throw new Error('Method not implemented.');
+    throw new UnreachableCaseError();
   }
 
   visitGenericAssociation(ctx: GenericAssociationContext): BaseNode {
-    throw new Error('Method not implemented.');
+    throw new UnreachableCaseError();
   }
 
   visitGenericSelection(ctx: GenericSelectionContext): Expression {

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -131,7 +131,11 @@ import {
   type VisitTypeSpecifierReturnValue
 } from './astBuilderInternalTypes';
 import { isTypedefNameReturnValue } from './typeGuards';
-import { constructEmptyStatement, constructIdentifier } from './constructors';
+import {
+  constructConstant,
+  constructEmptyStatement,
+  constructIdentifier
+} from './constructors';
 
 export class ASTBuilder implements CVisitor<any> {
   visit(tree: ParseTree): BaseNode {
@@ -855,6 +859,11 @@ export class ASTBuilder implements CVisitor<any> {
     const identifier = ctx.Identifier();
     if (identifier !== undefined) {
       return constructIdentifier(identifier);
+    }
+
+    const constant = ctx.Constant();
+    if (constant !== undefined) {
+      return constructConstant(constant);
     }
 
     // TODO: Deal with everything else.

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -134,7 +134,8 @@ import { isTypedefNameReturnValue } from './typeGuards';
 import {
   constructConstant,
   constructEmptyStatement,
-  constructIdentifier
+  constructIdentifier,
+  constructStringLiteral
 } from './constructors';
 
 export class ASTBuilder implements CVisitor<any> {
@@ -864,6 +865,16 @@ export class ASTBuilder implements CVisitor<any> {
     const constant = ctx.Constant();
     if (constant !== undefined) {
       return constructConstant(constant);
+    }
+
+    const stringLiterals = ctx.StringLiteral();
+    if (stringLiterals.length !== 0) {
+      if (stringLiterals.length > 1) {
+        throw new BrokenInvariantError(
+          'Encountered a StringLiteral with multiple strings.'
+        );
+      }
+      return constructStringLiteral(stringLiterals[0]);
     }
 
     // TODO: Deal with everything else.

--- a/src/ast/astBuilderInternalTypes.ts
+++ b/src/ast/astBuilderInternalTypes.ts
@@ -1,6 +1,6 @@
 import { type TypeSpecifier } from './keywordWhitelists/typeSpecifiers';
 import {
-  type Expression,
+  type ExpressionSequence,
   type Identifier,
   type VariableDeclaration
 } from './types';
@@ -67,7 +67,7 @@ export interface AlignmentSpecifierReturnValue extends BaseReturnValue {
 
 export interface ForCondition extends BaseReturnValue {
   type: 'ForCondition';
-  init?: VariableDeclaration | Expression;
-  test?: Expression[];
-  update?: Expression[];
+  init?: VariableDeclaration | ExpressionSequence;
+  test?: ExpressionSequence;
+  update?: ExpressionSequence;
 }

--- a/src/ast/astBuilderInternalTypes.ts
+++ b/src/ast/astBuilderInternalTypes.ts
@@ -1,6 +1,5 @@
 import { type TypeSpecifier } from './keywordWhitelists/typeSpecifiers';
 import {
-  type AssignmentExpression,
   type Expression,
   type Identifier,
   type VariableDeclaration
@@ -69,6 +68,6 @@ export interface AlignmentSpecifierReturnValue extends BaseReturnValue {
 export interface ForCondition extends BaseReturnValue {
   type: 'ForCondition';
   init?: VariableDeclaration | Expression;
-  test?: AssignmentExpression[];
-  update?: AssignmentExpression[];
+  test?: Expression[];
+  update?: Expression[];
 }

--- a/src/ast/constructors.ts
+++ b/src/ast/constructors.ts
@@ -1,5 +1,10 @@
 import { type TerminalNode } from 'antlr4ts/tree';
-import { type Constant, type EmptyStatement, type Identifier } from './types';
+import {
+  type Constant,
+  type EmptyStatement,
+  type Identifier,
+  type StringLiteral
+} from './types';
 
 export const constructConstant = (constant: TerminalNode): Constant => {
   return {
@@ -18,5 +23,14 @@ export const constructIdentifier = (identifier: TerminalNode): Identifier => {
   return {
     type: 'Identifier',
     name: identifier.toString()
+  };
+};
+
+export const constructStringLiteral = (
+  stringLiteral: TerminalNode
+): StringLiteral => {
+  return {
+    type: 'StringLiteral',
+    value: stringLiteral.toString()
   };
 };

--- a/src/ast/constructors.ts
+++ b/src/ast/constructors.ts
@@ -13,12 +13,3 @@ export const constructEmptyStatement = (): EmptyStatement => {
     type: 'EmptyStatement'
   };
 };
-
-export const constructPlaceholderIdentifier = (
-  placeholder: string
-): Identifier => {
-  return {
-    type: 'Identifier',
-    name: placeholder
-  };
-};

--- a/src/ast/constructors.ts
+++ b/src/ast/constructors.ts
@@ -1,15 +1,22 @@
 import { type TerminalNode } from 'antlr4ts/tree';
-import { type EmptyStatement, type Identifier } from './types';
+import { type Constant, type EmptyStatement, type Identifier } from './types';
 
-export const constructIdentifier = (identifier: TerminalNode): Identifier => {
+export const constructConstant = (constant: TerminalNode): Constant => {
   return {
-    type: 'Identifier',
-    name: identifier.toString()
+    type: 'Constant',
+    value: constant.toString()
   };
 };
 
 export const constructEmptyStatement = (): EmptyStatement => {
   return {
     type: 'EmptyStatement'
+  };
+};
+
+export const constructIdentifier = (identifier: TerminalNode): Identifier => {
+  return {
+    type: 'Identifier',
+    name: identifier.toString()
   };
 };

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -47,21 +47,21 @@ export interface EmptyStatement extends BaseStatement {
 
 export interface ExpressionStatement extends BaseStatement {
   type: 'ExpressionStatement';
-  expression: Expression;
+  sequence: ExpressionSequence;
 }
 
 export type SelectionStatement = IfStatement | SwitchStatement;
 
 export interface IfStatement extends BaseStatement {
   type: 'IfStatement';
-  test: Expression;
+  test: ExpressionSequence;
   consequent: Statement;
   alternate?: Statement;
 }
 
 export interface SwitchStatement extends BaseStatement {
   type: 'SwitchStatement';
-  discriminant: Expression;
+  discriminant: ExpressionSequence;
   body: Statement;
 }
 
@@ -72,21 +72,21 @@ export type IterationStatement =
 
 export interface DoWhileStatement extends BaseStatement {
   type: 'DoWhileStatement';
-  test: Expression;
+  test: ExpressionSequence;
   body: Statement;
 }
 
 export interface ForStatement extends BaseStatement {
   type: 'ForStatement';
-  init?: VariableDeclaration | Expression;
-  test?: Expression[];
-  update?: Expression[];
+  init?: VariableDeclaration | ExpressionSequence;
+  test?: ExpressionSequence;
+  update?: ExpressionSequence;
   body: Statement;
 }
 
 export interface WhileStatement extends BaseStatement {
   type: 'WhileStatement';
-  test: Expression;
+  test: ExpressionSequence;
   body: Statement;
 }
 
@@ -111,7 +111,12 @@ export interface GotoStatement extends BaseStatement {
 
 export interface ReturnStatement extends BaseStatement {
   type: 'ReturnStatement';
-  argument?: Expression;
+  argument?: ExpressionSequence;
+}
+
+export interface ExpressionSequence extends BaseNode {
+  type: 'ExpressionSequence';
+  expressions: Expression[];
 }
 
 export type Expression = AssignmentExpression | Identifier;

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -124,6 +124,7 @@ export type Expression =
   | BinaryExpression
   | Constant
   | Identifier
+  | LogicalExpression
   | StringLiteral;
 
 export interface BaseExpression extends BaseNode {}
@@ -167,6 +168,15 @@ export type BinaryOperator =
   | '&'
   | '^'
   | '|';
+
+export interface LogicalExpression extends BaseExpression {
+  type: 'LogicalExpression';
+  operator: LogicalOperator;
+  left: Expression;
+  right: Expression;
+}
+
+export type LogicalOperator = '&&' | '||';
 
 export interface AssignmentExpression extends BaseExpression {
   type: 'AssignmentExpression';

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -119,13 +119,18 @@ export interface ExpressionSequence extends BaseNode {
   expressions: Expression[];
 }
 
-export type Expression = AssignmentExpression | Identifier;
+export type Expression = AssignmentExpression | Constant | Identifier;
 
 export interface BaseExpression extends BaseNode {}
 
 export interface Identifier extends BaseExpression {
   type: 'Identifier';
   name: string;
+}
+
+export interface Constant extends BaseExpression {
+  type: 'Constant';
+  value: string;
 }
 
 export interface AssignmentExpression extends BaseExpression {

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -119,7 +119,11 @@ export interface ExpressionSequence extends BaseNode {
   expressions: Expression[];
 }
 
-export type Expression = AssignmentExpression | Constant | Identifier;
+export type Expression =
+  | AssignmentExpression
+  | Constant
+  | Identifier
+  | StringLiteral;
 
 export interface BaseExpression extends BaseNode {}
 
@@ -130,6 +134,11 @@ export interface Identifier extends BaseExpression {
 
 export interface Constant extends BaseExpression {
   type: 'Constant';
+  value: string;
+}
+
+export interface StringLiteral extends BaseExpression {
+  type: 'StringLiteral';
   value: string;
 }
 

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -79,8 +79,8 @@ export interface DoWhileStatement extends BaseStatement {
 export interface ForStatement extends BaseStatement {
   type: 'ForStatement';
   init?: VariableDeclaration | Expression;
-  test?: AssignmentExpression[];
-  update?: AssignmentExpression[];
+  test?: Expression[];
+  update?: Expression[];
   body: Statement;
 }
 

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -121,6 +121,7 @@ export interface ExpressionSequence extends BaseNode {
 
 export type Expression =
   | AssignmentExpression
+  | BinaryExpression
   | Constant
   | Identifier
   | StringLiteral;
@@ -141,6 +142,31 @@ export interface StringLiteral extends BaseExpression {
   type: 'StringLiteral';
   value: string;
 }
+
+export interface BinaryExpression extends BaseExpression {
+  type: 'BinaryExpression';
+  operator: BinaryOperator;
+  left: Expression;
+  right: Expression;
+}
+
+export type BinaryOperator =
+  | '*'
+  | '/'
+  | '%'
+  | '+'
+  | '-'
+  | '<<'
+  | '>>'
+  | '<'
+  | '>'
+  | '<='
+  | '>='
+  | '=='
+  | '!='
+  | '&'
+  | '^'
+  | '|';
 
 export interface AssignmentExpression extends BaseExpression {
   type: 'AssignmentExpression';

--- a/src/parser/__tests__/expressions/additiveExpression.ts
+++ b/src/parser/__tests__/expressions/additiveExpression.ts
@@ -1,0 +1,220 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('additive expression', () => {
+  test('handles addition', () => {
+    const code = 'int main() { 3 + 7; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '+',
+                    left: {
+                      type: 'Constant',
+                      value: '3'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '7'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles subtraction', () => {
+    const code = 'int main() { 8 - 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '-',
+                    left: {
+                      type: 'Constant',
+                      value: '8'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 4 + 3 - 2 - 6 + 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '+',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '-',
+                      left: {
+                        type: 'BinaryExpression',
+                        operator: '-',
+                        left: {
+                          type: 'BinaryExpression',
+                          operator: '+',
+                          left: {
+                            type: 'Constant',
+                            value: '4'
+                          },
+                          right: {
+                            type: 'Constant',
+                            value: '3'
+                          }
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '2'
+                        }
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '6'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than *, /, %', () => {
+    const code = 'int main() { 7 * 3 + 2 / 6 - 5 % 4; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '-',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '+',
+                      left: {
+                        type: 'BinaryExpression',
+                        operator: '*',
+                        left: {
+                          type: 'Constant',
+                          value: '7'
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '3'
+                        }
+                      },
+                      right: {
+                        type: 'BinaryExpression',
+                        operator: '/',
+                        left: {
+                          type: 'Constant',
+                          value: '2'
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '6'
+                        }
+                      }
+                    },
+                    right: {
+                      type: 'BinaryExpression',
+                      operator: '%',
+                      left: {
+                        type: 'Constant',
+                        value: '5'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '4'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/andExpression.ts
+++ b/src/parser/__tests__/expressions/andExpression.ts
@@ -1,0 +1,148 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('and expression', () => {
+  test('handles bitwise AND', () => {
+    const code = 'int main() { 4 & 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '&',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 1 & 2 & 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '&',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '&',
+                      left: {
+                        type: 'Constant',
+                        value: '1'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '2'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than ==, !=', () => {
+    const code = 'int main() { 1 == 2 & 3 != 4; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '&',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '==',
+                      left: {
+                        type: 'Constant',
+                        value: '1'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '2'
+                      }
+                    },
+                    right: {
+                      type: 'BinaryExpression',
+                      operator: '!=',
+                      left: {
+                        type: 'Constant',
+                        value: '3'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '4'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/equalityExpression.ts
+++ b/src/parser/__tests__/expressions/equalityExpression.ts
@@ -1,0 +1,228 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('equality expression', () => {
+  test('handles equality', () => {
+    const code = 'int main() { 4 == 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '==',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles inequality', () => {
+    const code = 'int main() { 4 != 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '!=',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 1 == 2 != 3 != 4 == 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '==',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '!=',
+                      left: {
+                        type: 'BinaryExpression',
+                        operator: '!=',
+                        left: {
+                          type: 'BinaryExpression',
+                          operator: '==',
+                          left: {
+                            type: 'Constant',
+                            value: '1'
+                          },
+                          right: {
+                            type: 'Constant',
+                            value: '2'
+                          }
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '3'
+                        }
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '4'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than <, >, <=, >=', () => {
+    const code = 'int main() { 1 < 2 == 3 > 4 <= 5 != 6 >= 7; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '!=',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '==',
+                      left: {
+                        type: 'BinaryExpression',
+                        operator: '<',
+                        left: {
+                          type: 'Constant',
+                          value: '1'
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '2'
+                        }
+                      },
+                      right: {
+                        type: 'BinaryExpression',
+                        operator: '<=',
+                        left: {
+                          type: 'BinaryExpression',
+                          operator: '>',
+                          left: {
+                            type: 'Constant',
+                            value: '3'
+                          },
+                          right: {
+                            type: 'Constant',
+                            value: '4'
+                          }
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '5'
+                        }
+                      }
+                    },
+                    right: {
+                      type: 'BinaryExpression',
+                      operator: '>=',
+                      left: {
+                        type: 'Constant',
+                        value: '6'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '7'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/exclusiveOrExpression.ts
+++ b/src/parser/__tests__/expressions/exclusiveOrExpression.ts
@@ -1,0 +1,140 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('exclusive or expression', () => {
+  test('handles bitwise XOR', () => {
+    const code = 'int main() { 4 ^ 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '^',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 1 ^ 2 ^ 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '^',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '^',
+                      left: {
+                        type: 'Constant',
+                        value: '1'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '2'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than &', () => {
+    const code = 'int main() { 1 ^ 2 & 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '^',
+                    left: {
+                      type: 'Constant',
+                      value: '1'
+                    },
+                    right: {
+                      type: 'BinaryExpression',
+                      operator: '&',
+                      left: {
+                        type: 'Constant',
+                        value: '2'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '3'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/inclusiveOrExpression.ts
+++ b/src/parser/__tests__/expressions/inclusiveOrExpression.ts
@@ -1,0 +1,140 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('inclusive or expression', () => {
+  test('handles bitwise OR', () => {
+    const code = 'int main() { 4 | 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '|',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 1 | 2 | 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '|',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '|',
+                      left: {
+                        type: 'Constant',
+                        value: '1'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '2'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than ^', () => {
+    const code = 'int main() { 1 | 2 ^ 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '|',
+                    left: {
+                      type: 'Constant',
+                      value: '1'
+                    },
+                    right: {
+                      type: 'BinaryExpression',
+                      operator: '^',
+                      left: {
+                        type: 'Constant',
+                        value: '2'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '3'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/logicalAndExpression.ts
+++ b/src/parser/__tests__/expressions/logicalAndExpression.ts
@@ -1,0 +1,140 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('logical and expression', () => {
+  test('handles logical AND', () => {
+    const code = 'int main() { 1 && 0; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'LogicalExpression',
+                    operator: '&&',
+                    left: {
+                      type: 'Constant',
+                      value: '1'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '0'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 1 && 2 && 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'LogicalExpression',
+                    operator: '&&',
+                    left: {
+                      type: 'LogicalExpression',
+                      operator: '&&',
+                      left: {
+                        type: 'Constant',
+                        value: '1'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '2'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than |', () => {
+    const code = 'int main() { 1 && 2 | 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'LogicalExpression',
+                    operator: '&&',
+                    left: {
+                      type: 'Constant',
+                      value: '1'
+                    },
+                    right: {
+                      type: 'BinaryExpression',
+                      operator: '|',
+                      left: {
+                        type: 'Constant',
+                        value: '2'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '3'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/logicalOrExpression.ts
+++ b/src/parser/__tests__/expressions/logicalOrExpression.ts
@@ -1,0 +1,140 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('logical or expression', () => {
+  test('handles logical OR', () => {
+    const code = 'int main() { 1 || 0; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'LogicalExpression',
+                    operator: '||',
+                    left: {
+                      type: 'Constant',
+                      value: '1'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '0'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 1 || 2 || 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'LogicalExpression',
+                    operator: '||',
+                    left: {
+                      type: 'LogicalExpression',
+                      operator: '||',
+                      left: {
+                        type: 'Constant',
+                        value: '1'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '2'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than &&', () => {
+    const code = 'int main() { 1 || 2 && 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'LogicalExpression',
+                    operator: '||',
+                    left: {
+                      type: 'Constant',
+                      value: '1'
+                    },
+                    right: {
+                      type: 'LogicalExpression',
+                      operator: '&&',
+                      left: {
+                        type: 'Constant',
+                        value: '2'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '3'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/multiplicativeExpression.ts
+++ b/src/parser/__tests__/expressions/multiplicativeExpression.ts
@@ -1,0 +1,204 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('multiplicative expression', () => {
+  test('handles multiplication', () => {
+    const code = 'int main() { 2 * 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '*',
+                    left: {
+                      type: 'Constant',
+                      value: '2'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles division', () => {
+    const code = 'int main() { 10 / 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '/',
+                    left: {
+                      type: 'Constant',
+                      value: '10'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles modulo', () => {
+    const code = 'int main() { 7 % 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '%',
+                    left: {
+                      type: 'Constant',
+                      value: '7'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 10 * 2 / 5 % 3 % 1 / 4 * 7; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '*',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '/',
+                      left: {
+                        type: 'BinaryExpression',
+                        operator: '%',
+                        left: {
+                          type: 'BinaryExpression',
+                          operator: '%',
+                          left: {
+                            type: 'BinaryExpression',
+                            operator: '/',
+                            left: {
+                              type: 'BinaryExpression',
+                              operator: '*',
+                              left: {
+                                type: 'Constant',
+                                value: '10'
+                              },
+                              right: {
+                                type: 'Constant',
+                                value: '2'
+                              }
+                            },
+                            right: {
+                              type: 'Constant',
+                              value: '5'
+                            }
+                          },
+                          right: {
+                            type: 'Constant',
+                            value: '3'
+                          }
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '1'
+                        }
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '4'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '7'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/primaryExpression.ts
+++ b/src/parser/__tests__/expressions/primaryExpression.ts
@@ -217,4 +217,16 @@ describe('primary expression', () => {
       "'__extension__' is a valid keyword in C17 but is not (currently) supported."
     );
   });
+
+  test("throws UnsupportedKeywordError for __builtin_va_arg'", () => {
+    const code = `
+      int main(void) {
+        // Invalid program - we only want to test that the keyword '__builtin_va_arg' is banned.
+        __builtin_va_arg(a, int);
+      }
+    `;
+    expect(() => parse(code)).toThrow(
+      "'__builtin_va_arg' is a valid keyword in C17 but is not (currently) supported."
+    );
+  });
 });

--- a/src/parser/__tests__/expressions/primaryExpression.ts
+++ b/src/parser/__tests__/expressions/primaryExpression.ts
@@ -33,4 +33,132 @@ describe('primary expression', () => {
     };
     expect(ast).toEqual(expectedAst);
   });
+
+  test('handles integer constants', () => {
+    const code = 'int main() { 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'Constant',
+                    value: '4215'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles floating constants', () => {
+    const code = 'int main() { 123.45; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'Constant',
+                    value: '123.45'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles integer constants', () => {
+    const code = 'int main() { 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'Constant',
+                    value: '4215'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles character constants', () => {
+    const code = "int main() { 'h'; }";
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'Constant',
+                    value: "'h'"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
 });

--- a/src/parser/__tests__/expressions/primaryExpression.ts
+++ b/src/parser/__tests__/expressions/primaryExpression.ts
@@ -1,0 +1,36 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('primary expression', () => {
+  test('handles identifiers', () => {
+    const code = 'int main() { a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'Identifier',
+                    name: 'a'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/primaryExpression.ts
+++ b/src/parser/__tests__/expressions/primaryExpression.ts
@@ -205,4 +205,16 @@ describe('primary expression', () => {
       "'_Generic' is a valid keyword in C17 but is not (currently) supported."
     );
   });
+
+  test("throws UnsupportedKeywordError for '__extension__'", () => {
+    const code = `
+      int main(void) {
+        // Invalid program - we only want to test that the keyword '__extension__' is banned.
+        __extension__({});
+      }
+    `;
+    expect(() => parse(code)).toThrow(
+      "'__extension__' is a valid keyword in C17 but is not (currently) supported."
+    );
+  });
 });

--- a/src/parser/__tests__/expressions/primaryExpression.ts
+++ b/src/parser/__tests__/expressions/primaryExpression.ts
@@ -161,4 +161,36 @@ describe('primary expression', () => {
     };
     expect(ast).toEqual(expectedAst);
   });
+
+  test('handles string literals', () => {
+    const code = 'int main() { "Hello world!"; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'StringLiteral',
+                    value: '"Hello world!"'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
 });

--- a/src/parser/__tests__/expressions/primaryExpression.ts
+++ b/src/parser/__tests__/expressions/primaryExpression.ts
@@ -193,4 +193,16 @@ describe('primary expression', () => {
     };
     expect(ast).toEqual(expectedAst);
   });
+
+  test("throws UnsupportedKeywordError for '_Generic'", () => {
+    const code = `
+      int main(void) {
+        // Invalid program - we only want to test that the keyword '_Generic' is banned.
+        _Generic((X), long double: cbrtl, default: cbrt, float: cbrtf)(X);
+      }
+    `;
+    expect(() => parse(code)).toThrow(
+      "'_Generic' is a valid keyword in C17 but is not (currently) supported."
+    );
+  });
 });

--- a/src/parser/__tests__/expressions/primaryExpression.ts
+++ b/src/parser/__tests__/expressions/primaryExpression.ts
@@ -218,7 +218,7 @@ describe('primary expression', () => {
     );
   });
 
-  test("throws UnsupportedKeywordError for __builtin_va_arg'", () => {
+  test("throws UnsupportedKeywordError for '__builtin_va_arg'", () => {
     const code = `
       int main(void) {
         // Invalid program - we only want to test that the keyword '__builtin_va_arg' is banned.
@@ -227,6 +227,18 @@ describe('primary expression', () => {
     `;
     expect(() => parse(code)).toThrow(
       "'__builtin_va_arg' is a valid keyword in C17 but is not (currently) supported."
+    );
+  });
+
+  test("throws UnsupportedKeywordError for '__builtin_offsetof'", () => {
+    const code = `
+      int main(void) {
+        // Invalid program - we only want to test that the keyword '__builtin_offsetof' is banned.
+        __builtin_offsetof(int, a);
+      }
+    `;
+    expect(() => parse(code)).toThrow(
+      "'__builtin_offsetof' is a valid keyword in C17 but is not (currently) supported."
     );
   });
 });

--- a/src/parser/__tests__/expressions/relationalExpression.ts
+++ b/src/parser/__tests__/expressions/relationalExpression.ts
@@ -1,0 +1,340 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('relational expression', () => {
+  test('handles less than', () => {
+    const code = 'int main() { 4 < 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '<',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles greater than', () => {
+    const code = 'int main() { 4 > 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '>',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles less than or equals to', () => {
+    const code = 'int main() { 4 <= 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '<=',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles greater than or equals to', () => {
+    const code = 'int main() { 4 >= 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '>=',
+                    left: {
+                      type: 'Constant',
+                      value: '4'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 1 < 2 > 3 <= 4 >= 5 >= 6 <= 7 > 8 < 9; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '<',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '>',
+                      left: {
+                        type: 'BinaryExpression',
+                        operator: '<=',
+                        left: {
+                          type: 'BinaryExpression',
+                          operator: '>=',
+                          left: {
+                            type: 'BinaryExpression',
+                            operator: '>=',
+                            left: {
+                              type: 'BinaryExpression',
+                              operator: '<=',
+                              left: {
+                                type: 'BinaryExpression',
+                                operator: '>',
+                                left: {
+                                  type: 'BinaryExpression',
+                                  operator: '<',
+                                  left: {
+                                    type: 'Constant',
+                                    value: '1'
+                                  },
+                                  right: {
+                                    type: 'Constant',
+                                    value: '2'
+                                  }
+                                },
+                                right: {
+                                  type: 'Constant',
+                                  value: '3'
+                                }
+                              },
+                              right: {
+                                type: 'Constant',
+                                value: '4'
+                              }
+                            },
+                            right: {
+                              type: 'Constant',
+                              value: '5'
+                            }
+                          },
+                          right: {
+                            type: 'Constant',
+                            value: '6'
+                          }
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '7'
+                        }
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '8'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '9'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than <<, >>', () => {
+    const code = 'int main() { 1 < 2 << 3 > 4 <= 5 >> 6 >= 7; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '>=',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '<=',
+                      left: {
+                        type: 'BinaryExpression',
+                        operator: '>',
+                        left: {
+                          type: 'BinaryExpression',
+                          operator: '<',
+                          left: {
+                            type: 'Constant',
+                            value: '1'
+                          },
+                          right: {
+                            type: 'BinaryExpression',
+                            operator: '<<',
+                            left: {
+                              type: 'Constant',
+                              value: '2'
+                            },
+                            right: {
+                              type: 'Constant',
+                              value: '3'
+                            }
+                          }
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '4'
+                        }
+                      },
+                      right: {
+                        type: 'BinaryExpression',
+                        operator: '>>',
+                        left: {
+                          type: 'Constant',
+                          value: '5'
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '6'
+                        }
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '7'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/shiftExpression.ts
+++ b/src/parser/__tests__/expressions/shiftExpression.ts
@@ -1,0 +1,212 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('shift expression', () => {
+  test('handles left shift', () => {
+    const code = 'int main() { 4215 << 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '<<',
+                    left: {
+                      type: 'Constant',
+                      value: '4215'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles right shift', () => {
+    const code = 'int main() { 4215 >> 3; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '>>',
+                    left: {
+                      type: 'Constant',
+                      value: '4215'
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '3'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('is left associative', () => {
+    const code = 'int main() { 4215 << 2 >> 3 >> 4 << 5; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '<<',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '>>',
+                      left: {
+                        type: 'BinaryExpression',
+                        operator: '>>',
+                        left: {
+                          type: 'BinaryExpression',
+                          operator: '<<',
+                          left: {
+                            type: 'Constant',
+                            value: '4215'
+                          },
+                          right: {
+                            type: 'Constant',
+                            value: '2'
+                          }
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '3'
+                        }
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '4'
+                      }
+                    },
+                    right: {
+                      type: 'Constant',
+                      value: '5'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('has lower precedence than +, -', () => {
+    const code = 'int main() { 4215 << 3 + 4 >> 2 - 1; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ExpressionStatement',
+              sequence: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'BinaryExpression',
+                    operator: '>>',
+                    left: {
+                      type: 'BinaryExpression',
+                      operator: '<<',
+                      left: {
+                        type: 'Constant',
+                        value: '4215'
+                      },
+                      right: {
+                        type: 'BinaryExpression',
+                        operator: '+',
+                        left: {
+                          type: 'Constant',
+                          value: '3'
+                        },
+                        right: {
+                          type: 'Constant',
+                          value: '4'
+                        }
+                      }
+                    },
+                    right: {
+                      type: 'BinaryExpression',
+                      operator: '-',
+                      left: {
+                        type: 'Constant',
+                        value: '2'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: '1'
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/statements/jumpStatement.ts
+++ b/src/parser/__tests__/statements/jumpStatement.ts
@@ -2,33 +2,37 @@ import { parse } from '../../parser';
 import { type Program } from '../../../ast/types';
 
 describe('return statement', () => {
-  // TODO: Fix this test case.
-  // it('handles argument', () => {
-  //   const code = 'int main() { return 0; }';
-  //   const ast = parse(code);
-  //   const expectedAst: Program = {
-  //     type: 'Program',
-  //     body: [
-  //       {
-  //         type: 'FunctionDeclaration',
-  //         id: {
-  //           type: 'Identifier',
-  //           name: 'main'
-  //         },
-  //         body: [
-  //           {
-  //             type: 'ReturnStatement',
-  //             argument: {
-  //               type: 'ExpressionSequence',
-  //               expressions: []
-  //             }
-  //           }
-  //         ]
-  //       }
-  //     ]
-  //   };
-  //   expect(ast).toEqual(expectedAst);
-  // });
+  it('handles argument', () => {
+    const code = 'int main() { return 0; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'ReturnStatement',
+              argument: {
+                type: 'ExpressionSequence',
+                expressions: [
+                  {
+                    type: 'Constant',
+                    value: '0'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
 
   it('handles no argument', () => {
     const code = 'int f() { return; }';
@@ -55,45 +59,49 @@ describe('return statement', () => {
 });
 
 describe('goto statement', () => {
-  // TODO: Fix this test case.
-  // it('goes to identifier', () => {
-  //   const code = 'int main() { x : return 0; goto x; }';
-  //   const ast = parse(code);
-  //   const expectedAst: Program = {
-  //     type: 'Program',
-  //     body: [
-  //       {
-  //         type: 'FunctionDeclaration',
-  //         id: {
-  //           type: 'Identifier',
-  //           name: 'main'
-  //         },
-  //         body: [
-  //           {
-  //             type: 'IdentifierStatement',
-  //             label: {
-  //               type: 'Identifier',
-  //               name: 'x'
-  //             },
-  //             body: {
-  //               type: 'ReturnStatement',
-  //               argument: {
-  //                 type: 'ExpressionSequence',
-  //                 expressions: []
-  //               }
-  //             }
-  //           },
-  //           {
-  //             type: 'GotoStatement',
-  //             argument: {
-  //               type: 'Identifier',
-  //               name: 'x'
-  //             }
-  //           }
-  //         ]
-  //       }
-  //     ]
-  //   };
-  //   expect(ast).toEqual(expectedAst);
-  // });
+  it('goes to identifier', () => {
+    const code = 'int main() { x : return 0; goto x; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: [
+            {
+              type: 'IdentifierStatement',
+              label: {
+                type: 'Identifier',
+                name: 'x'
+              },
+              body: {
+                type: 'ReturnStatement',
+                argument: {
+                  type: 'ExpressionSequence',
+                  expressions: [
+                    {
+                      type: 'Constant',
+                      value: '0'
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              type: 'GotoStatement',
+              argument: {
+                type: 'Identifier',
+                name: 'x'
+              }
+            }
+          ]
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
 });

--- a/src/parser/__tests__/statements/jumpStatement.ts
+++ b/src/parser/__tests__/statements/jumpStatement.ts
@@ -2,32 +2,33 @@ import { parse } from '../../parser';
 import { type Program } from '../../../ast/types';
 
 describe('return statement', () => {
-  it('handles argument', () => {
-    const code = 'int main() { return 0; }';
-    const ast = parse(code);
-    const expectedAst: Program = {
-      type: 'Program',
-      body: [
-        {
-          type: 'FunctionDeclaration',
-          id: {
-            type: 'Identifier',
-            name: 'main'
-          },
-          body: [
-            {
-              type: 'ReturnStatement',
-              argument: {
-                type: 'Identifier',
-                name: 'temp'
-              }
-            }
-          ]
-        }
-      ]
-    };
-    expect(ast).toEqual(expectedAst);
-  });
+  // TODO: Fix this test case.
+  // it('handles argument', () => {
+  //   const code = 'int main() { return 0; }';
+  //   const ast = parse(code);
+  //   const expectedAst: Program = {
+  //     type: 'Program',
+  //     body: [
+  //       {
+  //         type: 'FunctionDeclaration',
+  //         id: {
+  //           type: 'Identifier',
+  //           name: 'main'
+  //         },
+  //         body: [
+  //           {
+  //             type: 'ReturnStatement',
+  //             argument: {
+  //               type: 'ExpressionSequence',
+  //               expressions: []
+  //             }
+  //           }
+  //         ]
+  //       }
+  //     ]
+  //   };
+  //   expect(ast).toEqual(expectedAst);
+  // });
 
   it('handles no argument', () => {
     const code = 'int f() { return; }';
@@ -54,44 +55,45 @@ describe('return statement', () => {
 });
 
 describe('goto statement', () => {
-  it('goes to identifier', () => {
-    const code = 'int main() { x : return 0; goto x; }';
-    const ast = parse(code);
-    const expectedAst: Program = {
-      type: 'Program',
-      body: [
-        {
-          type: 'FunctionDeclaration',
-          id: {
-            type: 'Identifier',
-            name: 'main'
-          },
-          body: [
-            {
-              type: 'IdentifierStatement',
-              label: {
-                type: 'Identifier',
-                name: 'x'
-              },
-              body: {
-                type: 'ReturnStatement',
-                argument: {
-                  type: 'Identifier',
-                  name: 'temp'
-                }
-              }
-            },
-            {
-              type: 'GotoStatement',
-              argument: {
-                type: 'Identifier',
-                name: 'x'
-              }
-            }
-          ]
-        }
-      ]
-    };
-    expect(ast).toEqual(expectedAst);
-  });
+  // TODO: Fix this test case.
+  // it('goes to identifier', () => {
+  //   const code = 'int main() { x : return 0; goto x; }';
+  //   const ast = parse(code);
+  //   const expectedAst: Program = {
+  //     type: 'Program',
+  //     body: [
+  //       {
+  //         type: 'FunctionDeclaration',
+  //         id: {
+  //           type: 'Identifier',
+  //           name: 'main'
+  //         },
+  //         body: [
+  //           {
+  //             type: 'IdentifierStatement',
+  //             label: {
+  //               type: 'Identifier',
+  //               name: 'x'
+  //             },
+  //             body: {
+  //               type: 'ReturnStatement',
+  //               argument: {
+  //                 type: 'ExpressionSequence',
+  //                 expressions: []
+  //               }
+  //             }
+  //           },
+  //           {
+  //             type: 'GotoStatement',
+  //             argument: {
+  //               type: 'Identifier',
+  //               name: 'x'
+  //             }
+  //           }
+  //         ]
+  //       }
+  //     ]
+  //   };
+  //   expect(ast).toEqual(expectedAst);
+  // });
 });

--- a/src/parser/__tests__/topLevelVariableDeclarations/initialisation.ts
+++ b/src/parser/__tests__/topLevelVariableDeclarations/initialisation.ts
@@ -119,7 +119,7 @@ describe('Top-level variable declarations (initialisation)', () => {
   });
 
   it('handles initialised variable declarations', () => {
-    const code = 'int a = 5;';
+    const code = 'int a = b;';
     const ast = parse(code);
     const expectedAst: Program = {
       type: 'Program',
@@ -133,8 +133,11 @@ describe('Top-level variable declarations (initialisation)', () => {
               id: {
                 type: 'Identifier',
                 name: 'a'
+              },
+              initialValue: {
+                type: 'Identifier',
+                name: 'b'
               }
-              // TODO: Implement initial value.
             }
           ]
         }


### PR DESCRIPTION
Also throw errors for the `__extension__`, `__builtin_va_arg` and `__builtin_offsetof` keywords which we do not intend on supporting.

As discussed, C allows for sequences of expressions that are delimited by comma. For example, the output of the following program is 4:
```c
#include "stdio.h"

int f() {
    return 1, 2, 3;
}

int main() {
    int a = 2;
    int b = 0;
    if (b += 4, a < 3) {
        printf("%d\n", f());
    }
    printf("%d\n", b);
}
```

As such, the `ExpressionSequence` AST node was introduced to handle such sequences of expressions.

I will add support for the rest of the expressions in a separate PR because this one is getting quite large already.