### PR TITLE
Remove hacks to make CI jobs work

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,10 +20,6 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      # Necessary for the action to work until the following issue is fixed:
-      # https://github.com/EPMatt/reviewdog-action-prettier/issues/34
-      - name: Downgrade npm to v8
-        run: npm install -g npm@8
       - name: Format
         uses: EPMatt/reviewdog-action-prettier@v1
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -20,10 +20,6 @@ jobs:
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      # Necessary for the action to work until the following issue is fixed:
-      # https://github.com/EPMatt/reviewdog-action-tsc/issues/157
-      - name: Downgrade npm to v8
-        run: npm install -g npm@8
       - name: Typecheck
         uses: EPMatt/reviewdog-action-tsc@v1
         with:


### PR DESCRIPTION
The affected GitHub Actions have been patched. See the linked issues in the removed comments for more information.