### PR TITLE
Add parsing of UnaryExpressions, ConditionalExpressions & AssignmentExpressions from CST to AST

### DIFF
--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -17,7 +17,8 @@ import {
   type Statement,
   type VariableDeclaration,
   type VariableDeclarator,
-  type UnaryOperator
+  type UnaryOperator,
+  type AssignmentOperator
 } from './types';
 import {
   type ErrorNode,
@@ -236,14 +237,90 @@ export class ASTBuilder implements CVisitor<any> {
       return this.visitConditionalExpression(conditionalExpression);
     }
 
-    // TODO: Deal with assignments.
-    // TODO: Deal with number sequence.
-
-    throw new UnreachableCaseError();
+    const unaryExpression = ctx.unaryExpression();
+    const assignmentOperator = ctx.assignmentOperator();
+    const assignmentExpression = ctx.assignmentExpression();
+    if (
+      unaryExpression === undefined &&
+      assignmentOperator === undefined &&
+      assignmentExpression === undefined
+    ) {
+      throw new UnreachableCaseError();
+    }
+    if (
+      unaryExpression === undefined ||
+      assignmentOperator === undefined ||
+      assignmentExpression === undefined
+    ) {
+      throw new BrokenInvariantError(
+        'Encountered an AssignmentExpression where at least one of UnaryExpression, AssignmentOperator, and AssignmentExpression is undefined.'
+      );
+    }
+    return {
+      type: 'AssignmentExpression',
+      operator: this.visitAssignmentOperator(assignmentOperator),
+      left: this.visitUnaryExpression(unaryExpression),
+      right: this.visitAssignmentExpression(assignmentExpression)
+    };
   }
 
-  visitAssignmentOperator(ctx: AssignmentOperatorContext): BaseNode {
-    throw new Error('Method not implemented.');
+  visitAssignmentOperator(ctx: AssignmentOperatorContext): AssignmentOperator {
+    const assignmentOperator = ctx.Assign();
+    if (assignmentOperator !== undefined) {
+      return '=';
+    }
+
+    const multiplicationAssignmentOperator = ctx.StarAssign();
+    if (multiplicationAssignmentOperator !== undefined) {
+      return '*=';
+    }
+
+    const divisionAssignmentOperator = ctx.DivAssign();
+    if (divisionAssignmentOperator !== undefined) {
+      return '/=';
+    }
+
+    const remainderAssignmentOperator = ctx.ModAssign();
+    if (remainderAssignmentOperator !== undefined) {
+      return '%=';
+    }
+
+    const additionAssignmentOperator = ctx.PlusAssign();
+    if (additionAssignmentOperator !== undefined) {
+      return '+=';
+    }
+
+    const subtractionAssignmentOperator = ctx.MinusAssign();
+    if (subtractionAssignmentOperator !== undefined) {
+      return '-=';
+    }
+
+    const leftShiftAssignmentOperator = ctx.LeftShiftAssign();
+    if (leftShiftAssignmentOperator !== undefined) {
+      return '<<=';
+    }
+
+    const rightShiftAssignmentOperator = ctx.RightShiftAssign();
+    if (rightShiftAssignmentOperator !== undefined) {
+      return '>>=';
+    }
+
+    const bitwiseAndAssignmentOperator = ctx.AndAssign();
+    if (bitwiseAndAssignmentOperator !== undefined) {
+      return '&=';
+    }
+
+    const bitwiseXorAssignmentOperator = ctx.XorAssign();
+    if (bitwiseXorAssignmentOperator !== undefined) {
+      return '^=';
+    }
+
+    const bitwiseOrAssignmentOperator = ctx.OrAssign();
+    if (bitwiseOrAssignmentOperator !== undefined) {
+      return '|=';
+    }
+
+    throw new UnreachableCaseError();
   }
 
   visitAtomicTypeSpecifier(ctx: AtomicTypeSpecifierContext): BaseNode {

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -1531,33 +1531,38 @@ export class ASTBuilder implements CVisitor<any> {
       expression = this.visitPostfixExpression(postfixExpression);
     }
 
-    if (expression === undefined) {
-      const unaryOperator = ctx.unaryOperator();
-      const castExpression = ctx.castExpression();
-      if (unaryOperator !== undefined && castExpression === undefined) {
-        throw new BrokenInvariantError(
-          'Encountered a UnaryExpression with a UnaryOperator but no CastExpression.'
-        );
-      }
-      if (unaryOperator === undefined && castExpression !== undefined) {
-        throw new BrokenInvariantError(
-          'Encountered a UnaryExpression with a CastExpression but no UnaryOperator.'
-        );
-      }
-      if (unaryOperator !== undefined && castExpression !== undefined) {
-        expression = {
-          type: 'UnaryExpression',
-          operator: this.visitUnaryOperator(unaryOperator),
-          operand: this.visitCastExpression(castExpression)
-        };
-      }
+    const unaryOperator = ctx.unaryOperator();
+    const castExpression = ctx.castExpression();
+    if (
+      expression !== undefined &&
+      (unaryOperator !== undefined || castExpression !== undefined)
+    ) {
+      throw new BrokenInvariantError('Encountered an invalid UnaryExpression.');
+    }
+    if (unaryOperator !== undefined && castExpression === undefined) {
+      throw new BrokenInvariantError(
+        'Encountered a UnaryExpression with a UnaryOperator but no CastExpression.'
+      );
+    }
+    if (unaryOperator === undefined && castExpression !== undefined) {
+      throw new BrokenInvariantError(
+        'Encountered a UnaryExpression with a CastExpression but no UnaryOperator.'
+      );
+    }
+    if (unaryOperator !== undefined && castExpression !== undefined) {
+      expression = {
+        type: 'UnaryExpression',
+        operator: this.visitUnaryOperator(unaryOperator),
+        operand: this.visitCastExpression(castExpression)
+      };
     }
 
-    if (expression === undefined) {
-      const typeName = ctx.typeName();
-      if (typeName !== undefined) {
-        expression = this.visitTypeName(typeName);
-      }
+    const typeName = ctx.typeName();
+    if (expression !== undefined && typeName !== undefined) {
+      throw new BrokenInvariantError('Encountered an invalid UnaryExpression.');
+    }
+    if (typeName !== undefined) {
+      expression = this.visitTypeName(typeName);
     }
 
     const children = ctx.children;

--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -386,39 +386,30 @@ export class ASTBuilder implements CVisitor<any> {
     if (logicalOrExpression === undefined) {
       throw new UnreachableCaseError();
     }
-    let expression = this.visitLogicalOrExpression(logicalOrExpression);
+    let returnedExpression = this.visitLogicalOrExpression(logicalOrExpression);
 
-    const consequentExpression = ctx.expression();
-    const alternateExpression = ctx.conditionalExpression();
-    if (
-      consequentExpression !== undefined &&
-      alternateExpression === undefined
-    ) {
+    const expression = ctx.expression();
+    const conditionalExpression = ctx.conditionalExpression();
+    if (expression !== undefined && conditionalExpression === undefined) {
       throw new BrokenInvariantError(
         'Encountered a ConditionalExpression with an Expression but not ConditionalExpression.'
       );
     }
-    if (
-      consequentExpression === undefined &&
-      alternateExpression !== undefined
-    ) {
+    if (expression === undefined && conditionalExpression !== undefined) {
       throw new BrokenInvariantError(
         'Encountered a ConditionalExpression with a ConditionalExpression but not Expression.'
       );
     }
-    if (
-      consequentExpression !== undefined &&
-      alternateExpression !== undefined
-    ) {
-      expression = {
+    if (expression !== undefined && conditionalExpression !== undefined) {
+      returnedExpression = {
         type: 'ConditionalExpression',
-        predicate: expression,
-        consequent: this.visitExpression(consequentExpression),
-        alternate: this.visitConditionalExpression(alternateExpression)
+        predicate: returnedExpression,
+        consequent: this.visitExpression(expression),
+        alternate: this.visitConditionalExpression(conditionalExpression)
       };
     }
 
-    return expression;
+    return returnedExpression;
   }
 
   visitConstantExpression(ctx: ConstantExpressionContext): BaseNode {

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -145,6 +145,7 @@ export type Expression =
   | MemberExpression
   | SequenceExpression
   | StringLiteral
+  | UnaryExpression
   | UpdateExpression;
 
 export interface BaseExpression extends BaseNode {}
@@ -193,6 +194,14 @@ export interface UpdateExpression extends BaseExpression {
 }
 
 export type UpdateOperator = '++' | '--';
+
+export interface UnaryExpression extends BaseExpression {
+  type: 'UnaryExpression';
+  operator: UnaryOperator;
+  operand: Expression;
+}
+
+export type UnaryOperator = '&' | '*' | '+' | '-' | '~' | '!' | 'sizeof';
 
 export interface BinaryExpression extends BaseExpression {
   type: 'BinaryExpression';

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -69,7 +69,7 @@ export type SelectionStatement = IfStatement | SwitchStatement;
 
 export interface IfStatement extends BaseStatement {
   type: 'IfStatement';
-  test: SequenceExpression;
+  predicate: SequenceExpression;
   consequent: Statement;
   alternate?: Statement;
 }
@@ -139,6 +139,7 @@ export type Expression =
   | AssignmentExpression
   | BinaryExpression
   | CallExpression
+  | ConditionalExpression
   | Constant
   | Identifier
   | LogicalExpression
@@ -236,6 +237,13 @@ export interface LogicalExpression extends BaseExpression {
 }
 
 export type LogicalOperator = '&&' | '||';
+
+export interface ConditionalExpression extends BaseExpression {
+  type: 'ConditionalExpression';
+  predicate: Expression;
+  consequent: Expression;
+  alternate: Expression;
+}
 
 export interface AssignmentExpression extends BaseExpression {
   type: 'AssignmentExpression';

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -248,8 +248,7 @@ export interface ConditionalExpression extends BaseExpression {
 export interface AssignmentExpression extends BaseExpression {
   type: 'AssignmentExpression';
   operator: AssignmentOperator;
-  // TODO: Not the final type.
-  left: string;
+  left: Expression;
   right: Expression;
 }
 

--- a/src/interpreter/explicitControlEvaluator.ts
+++ b/src/interpreter/explicitControlEvaluator.ts
@@ -34,7 +34,8 @@ import {
   type UpdateExpression,
   type VariableDeclaration,
   type WhileStatement,
-  type UnaryExpression
+  type UnaryExpression,
+  type ConditionalExpression
 } from '../ast/types';
 import {
   allocateStackAddresses,
@@ -207,6 +208,10 @@ const evaluators: AgendaItemEvaluatorMapping = {
       state.agenda.push(command.arguments[i]);
     }
   },
+  ConditionalExpression: (
+    command: ConditionalExpression,
+    state: ExplicitControlEvaluatorState
+  ) => {},
   Constant: (command: Constant, state: ExplicitControlEvaluatorState) => {
     state.stash.push(command.value);
   },

--- a/src/interpreter/explicitControlEvaluator.ts
+++ b/src/interpreter/explicitControlEvaluator.ts
@@ -33,7 +33,8 @@ import {
   type SwitchStatement,
   type UpdateExpression,
   type VariableDeclaration,
-  type WhileStatement
+  type WhileStatement,
+  type UnaryExpression
 } from '../ast/types';
 import {
   allocateStackAddresses,
@@ -407,6 +408,10 @@ const evaluators: AgendaItemEvaluatorMapping = {
   ) => {},
   SwitchStatement: (
     command: SwitchStatement,
+    state: ExplicitControlEvaluatorState
+  ) => {},
+  UnaryExpression: (
+    command: UnaryExpression,
     state: ExplicitControlEvaluatorState
   ) => {},
   UpdateExpression: (

--- a/src/parser/__tests__/expressions/assignmentExpression.ts
+++ b/src/parser/__tests__/expressions/assignmentExpression.ts
@@ -1,0 +1,601 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('assignment expression', () => {
+  test('handles simple assignment operator', () => {
+    const code = 'int main() { x = 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles multiplication assignment operator', () => {
+    const code = 'int main() { x *= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '*=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles division assignment operator', () => {
+    const code = 'int main() { x /= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '/=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles remainder assignment operator', () => {
+    const code = 'int main() { x %= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '%=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles addition assignment operator', () => {
+    const code = 'int main() { x += 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '+=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles subtraction assignment operator', () => {
+    const code = 'int main() { x -= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '-=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles left-shift assignment operator', () => {
+    const code = 'int main() { x <<= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '<<=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles right-shift assignment operator', () => {
+    const code = 'int main() { x >>= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '>>=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles bitwise AND assignment operator', () => {
+    const code = 'int main() { x &= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '&=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles bitwise XOR assignment operator', () => {
+    const code = 'int main() { x ^= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '^=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles bitwise OR assignment operator', () => {
+    const code = 'int main() { x |= 4215; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '|=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'x'
+                      },
+                      right: {
+                        type: 'Constant',
+                        value: 4215
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles chained assignment operators', () => {
+    const code =
+      'int main() { a = b *= c /= d %= e += f -= g <<= h >>= i &= j ^= k |= l; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'AssignmentExpression',
+                      operator: '=',
+                      left: {
+                        type: 'Identifier',
+                        name: 'a'
+                      },
+                      right: {
+                        type: 'AssignmentExpression',
+                        operator: '*=',
+                        left: {
+                          type: 'Identifier',
+                          name: 'b'
+                        },
+                        right: {
+                          type: 'AssignmentExpression',
+                          operator: '/=',
+                          left: {
+                            type: 'Identifier',
+                            name: 'c'
+                          },
+                          right: {
+                            type: 'AssignmentExpression',
+                            operator: '%=',
+                            left: {
+                              type: 'Identifier',
+                              name: 'd'
+                            },
+                            right: {
+                              type: 'AssignmentExpression',
+                              operator: '+=',
+                              left: {
+                                type: 'Identifier',
+                                name: 'e'
+                              },
+                              right: {
+                                type: 'AssignmentExpression',
+                                operator: '-=',
+                                left: {
+                                  type: 'Identifier',
+                                  name: 'f'
+                                },
+                                right: {
+                                  type: 'AssignmentExpression',
+                                  operator: '<<=',
+                                  left: {
+                                    type: 'Identifier',
+                                    name: 'g'
+                                  },
+                                  right: {
+                                    type: 'AssignmentExpression',
+                                    operator: '>>=',
+                                    left: {
+                                      type: 'Identifier',
+                                      name: 'h'
+                                    },
+                                    right: {
+                                      type: 'AssignmentExpression',
+                                      operator: '&=',
+                                      left: {
+                                        type: 'Identifier',
+                                        name: 'i'
+                                      },
+                                      right: {
+                                        type: 'AssignmentExpression',
+                                        operator: '^=',
+                                        left: {
+                                          type: 'Identifier',
+                                          name: 'j'
+                                        },
+                                        right: {
+                                          type: 'AssignmentExpression',
+                                          operator: '|=',
+                                          left: {
+                                            type: 'Identifier',
+                                            name: 'k'
+                                          },
+                                          right: {
+                                            type: 'Identifier',
+                                            name: 'l'
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/conditionalExpression.ts
+++ b/src/parser/__tests__/expressions/conditionalExpression.ts
@@ -1,0 +1,122 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('conditional expression', () => {
+  test('handles conditional operator', () => {
+    const code = 'int main() { a ? b : c; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'ConditionalExpression',
+                      predicate: {
+                        type: 'Identifier',
+                        name: 'a'
+                      },
+                      consequent: {
+                        type: 'SequenceExpression',
+                        expressions: [
+                          {
+                            type: 'Identifier',
+                            name: 'b'
+                          }
+                        ]
+                      },
+                      alternate: {
+                        type: 'Identifier',
+                        name: 'c'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles nested conditional operators', () => {
+    const code = 'int main() { a ? b : c ? d : e; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'ConditionalExpression',
+                      predicate: {
+                        type: 'Identifier',
+                        name: 'a'
+                      },
+                      consequent: {
+                        type: 'SequenceExpression',
+                        expressions: [
+                          {
+                            type: 'Identifier',
+                            name: 'b'
+                          }
+                        ]
+                      },
+                      alternate: {
+                        type: 'ConditionalExpression',
+                        predicate: {
+                          type: 'Identifier',
+                          name: 'c'
+                        },
+                        consequent: {
+                          type: 'SequenceExpression',
+                          expressions: [
+                            {
+                              type: 'Identifier',
+                              name: 'd'
+                            }
+                          ]
+                        },
+                        alternate: {
+                          type: 'Identifier',
+                          name: 'e'
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+});

--- a/src/parser/__tests__/expressions/unaryExpression.ts
+++ b/src/parser/__tests__/expressions/unaryExpression.ts
@@ -1,0 +1,442 @@
+import { parse } from '../../parser';
+import { type Program } from '../../../ast/types';
+
+describe('unary expression', () => {
+  test('handles prefix increment', () => {
+    const code = 'int main() { ++a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UpdateExpression',
+                      operator: '++',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      },
+                      isPrefix: true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles prefix decrement', () => {
+    const code = 'int main() { --a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UpdateExpression',
+                      operator: '--',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      },
+                      isPrefix: true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles sizeof operator', () => {
+    const code = 'int main() { sizeof a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UnaryExpression',
+                      operator: 'sizeof',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles address-of operator', () => {
+    const code = 'int main() { &a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UnaryExpression',
+                      operator: '&',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles indirection operator', () => {
+    const code = 'int main() { *a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UnaryExpression',
+                      operator: '*',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles unary plus operator', () => {
+    const code = 'int main() { +a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UnaryExpression',
+                      operator: '+',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles negation operator', () => {
+    const code = 'int main() { -a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UnaryExpression',
+                      operator: '-',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles bitwise not operator', () => {
+    const code = 'int main() { ~a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UnaryExpression',
+                      operator: '~',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles logical not operator', () => {
+    const code = 'int main() { !a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UnaryExpression',
+                      operator: '!',
+                      operand: {
+                        type: 'Identifier',
+                        name: 'a'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  test('handles chaining of unary operators', () => {
+    const code = 'int main() { ++--sizeof&*+-~!a; }';
+    const ast = parse(code);
+    const expectedAst: Program = {
+      type: 'Program',
+      body: [
+        {
+          type: 'FunctionDeclaration',
+          id: {
+            type: 'Identifier',
+            name: 'main'
+          },
+          body: {
+            type: 'BlockStatement',
+            items: [
+              {
+                type: 'ExpressionStatement',
+                sequence: {
+                  type: 'SequenceExpression',
+                  expressions: [
+                    {
+                      type: 'UpdateExpression',
+                      operator: '++',
+                      operand: {
+                        type: 'UpdateExpression',
+                        operator: '--',
+                        operand: {
+                          type: 'UnaryExpression',
+                          operator: 'sizeof',
+                          operand: {
+                            type: 'UnaryExpression',
+                            operator: '&',
+                            operand: {
+                              type: 'UnaryExpression',
+                              operator: '*',
+                              operand: {
+                                type: 'UnaryExpression',
+                                operator: '+',
+                                operand: {
+                                  type: 'UnaryExpression',
+                                  operator: '-',
+                                  operand: {
+                                    type: 'UnaryExpression',
+                                    operator: '~',
+                                    operand: {
+                                      type: 'UnaryExpression',
+                                      operator: '!',
+                                      operand: {
+                                        type: 'Identifier',
+                                        name: 'a'
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        isPrefix: true
+                      },
+                      isPrefix: true
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    };
+    expect(ast).toEqual(expectedAst);
+  });
+
+  // TODO: Enable this test case once TypeName parsing is supported.
+  // test("throws UnsupportedKeywordError for '_Alignof'", () => {
+  //   const code = `
+  //     int main(void) {
+  //       _Alignof(int);
+  //     }
+  //   `;
+  //   expect(() => parse(code)).toThrow(
+  //     "'_Alignof' is a valid keyword in C17 but is not (currently) supported."
+  //   );
+  // });
+});


### PR DESCRIPTION
Only cast expressions have not been done, but we will need to figure out how we want to handle the parsing of types (since they are made up of multiple distinct keywords where the order matters).