### PR TITLE
Throw errors when parsing instead of just logging

### DIFF
--- a/src/parser/errors.ts
+++ b/src/parser/errors.ts
@@ -1,0 +1,1 @@
+export class ParseError extends Error {}

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -3,6 +3,8 @@ import { CLexer } from '../lang/CLexer';
 import { CParser } from '../lang/CParser';
 import { ASTBuilder } from '../ast/astBuilder';
 import { type Program } from '../ast/types';
+import { ThrowingErrorListener } from './throwingErrorListener';
+import { type Token } from 'antlr4ts/Token';
 
 /**
  * Parses C code & returns its abstract syntax tree representation.
@@ -11,9 +13,19 @@ import { type Program } from '../ast/types';
  */
 export const parse = (code: string): Program => {
   const inputStream = CharStreams.fromString(code);
+
   const lexer = new CLexer(inputStream);
+  const lexerErrorListener = new ThrowingErrorListener<number>();
+  lexer.removeErrorListeners();
+  lexer.addErrorListener(lexerErrorListener);
+
   const tokens = new CommonTokenStream(lexer);
+
   const parser = new CParser(tokens);
+  const parserErrorListener = new ThrowingErrorListener<Token>();
+  parser.removeErrorListeners();
+  parser.addErrorListener(parserErrorListener);
+
   const astBuilder = new ASTBuilder();
   const cst = parser.compilationUnit();
   return astBuilder.visitCompilationUnit(cst);

--- a/src/parser/throwingErrorListener.ts
+++ b/src/parser/throwingErrorListener.ts
@@ -1,0 +1,16 @@
+import { type ANTLRErrorListener, type Recognizer } from 'antlr4ts';
+import { type RecognitionException } from 'antlr4ts/RecognitionException';
+import { ParseError } from './errors';
+
+export class ThrowingErrorListener<T> implements ANTLRErrorListener<T> {
+  public syntaxError(
+    recognizer: Recognizer<T, any>,
+    offendingSymbol: T | undefined,
+    line: number,
+    charPositionInLine: number,
+    msg: string,
+    e: RecognitionException | undefined
+  ): void {
+    throw new ParseError(`Line ${line}:${charPositionInLine} ${msg}`);
+  }
+}

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -16,7 +16,7 @@ const startRepl = (): void => {
           callback(null, result);
         })
         .catch((err) => {
-          callback(err, undefined);
+          callback(err.message, undefined);
         });
     }
   });


### PR DESCRIPTION
By default, the ANTLR parsers do not throw errors encountered during parsing.