### PR TITLE
Handle variable sizes

### DIFF
--- a/src/ast/astBuilder.ts
+++ b/src/ast/astBuilder.ts
@@ -1572,6 +1572,7 @@ export class ASTBuilder implements CVisitor<any> {
     const abstractDeclarator = ctx.abstractDeclarator();
     return {
       type: 'ParameterAbstractDeclaratorDeclaration',
+      dataType,
       declarator:
         abstractDeclarator === undefined
           ? undefined

--- a/src/ast/types/ast.ts
+++ b/src/ast/types/ast.ts
@@ -381,6 +381,7 @@ export interface ParameterDeclaratorDeclaration {
 export interface ParameterAbstractDeclaratorDeclaration {
   type: 'ParameterAbstractDeclaratorDeclaration';
   // TODO: Support declaration specifiers
+  dataType: DataType;
   declarator?: AbstractDeclaratorPattern;
 }
 

--- a/src/ast/types/dataTypes.ts
+++ b/src/ast/types/dataTypes.ts
@@ -1,11 +1,18 @@
-export type DataType = IntegerDataType | FloatingPointDataType | VoidDataType;
+export type DataType =
+  | AddressDataType
+  | BuiltInDataType
+  | IntegerDataType
+  | FloatingPointDataType
+  | VoidDataType;
 
 export interface VoidDataType {
   type: 'Void';
+  sizeInBytes: 0;
 }
 
 export const VOID: VoidDataType = {
-  type: 'Void'
+  type: 'Void',
+  sizeInBytes: 0
 };
 
 export interface IntegerDataType {
@@ -75,4 +82,36 @@ export const FLOAT32: FloatingPointDataType = {
 export const FLOAT64: FloatingPointDataType = {
   type: 'FloatingPoint',
   sizeInBytes: 8
+};
+
+export interface AddressDataType {
+  type: 'Address';
+  sizeInBytes: 8;
+  valueDataType: DataType;
+}
+
+export const ADDRESS_SIZE_IN_BYTES = 8;
+
+export const constructAddressDataType = (
+  valueDataType: DataType
+): AddressDataType => ({
+  type: 'Address',
+  sizeInBytes: ADDRESS_SIZE_IN_BYTES,
+  valueDataType
+});
+
+export const isAddressDataType = (
+  dataType: DataType
+): dataType is AddressDataType => {
+  return dataType.type === 'Address';
+};
+
+export interface BuiltInDataType {
+  type: 'Builtin';
+  sizeInBytes: 0;
+}
+
+export const BUILTIN: BuiltInDataType = {
+  type: 'Builtin',
+  sizeInBytes: 0
 };

--- a/src/interpreter/__tests__/functionDeclaration.ts
+++ b/src/interpreter/__tests__/functionDeclaration.ts
@@ -74,26 +74,4 @@ describe('function declaration', () => {
     const expectedResult = 6;
     expect(result).toEqual(expectedResult);
   });
-
-  test('handles pointers to pointers as function arguments', () => {
-    const code = `
-        void swap(int **x, int **y) {
-            int temp = **x;
-            **x = **y;
-            **y = temp;
-        }
-
-        int main() {
-            int x = 1, y = 7;
-            int *a = &x, *b = &y;
-            swap(&a, &b);
-            return x - y;
-        }
-    `;
-    const ast = parse(code);
-    const instructions = compileProgram(ast);
-    const result = interpret(instructions);
-    const expectedResult = 6;
-    expect(result).toEqual(expectedResult);
-  });
 });

--- a/src/interpreter/__tests__/returnStatement.ts
+++ b/src/interpreter/__tests__/returnStatement.ts
@@ -75,4 +75,49 @@ describe('return statement', () => {
     const expectedResult = 4;
     expect(result).toEqual(expectedResult);
   });
+
+  test('handles recursion', () => {
+    const code = `  
+        int fact(int n) {
+           if (n <= 1) {
+               return 1;
+           }
+           return n * fact(n - 1);
+        }  
+  
+        int main() {
+            return fact(4);
+        }
+    `;
+    const ast = parse(code);
+    const instructions = compileProgram(ast);
+    const result = interpret(instructions);
+    const expectedResult = 24;
+    expect(result).toEqual(expectedResult);
+  });
+
+  test('handles several function calls', () => {
+    const code = `  
+        int add(int n, int m) {
+            return n + m;
+        }
+        
+        int fact(int n) {
+           if (n <= 1) {
+               return 1;
+           }
+           return n * fact(n - 1);
+        }  
+  
+        int main() {
+            int num = add(3, 2);
+            return fact(num);
+        }
+    `;
+    const ast = parse(code);
+    const instructions = compileProgram(ast);
+    const result = interpret(instructions);
+    const expectedResult = 120;
+    expect(result).toEqual(expectedResult);
+  });
 });

--- a/src/interpreter/__tests__/types/declaration.ts
+++ b/src/interpreter/__tests__/types/declaration.ts
@@ -1,0 +1,191 @@
+import { parse } from '../../../parser/parser';
+import { compileProgram } from '../../compiler';
+import { interpret } from '../../virtualMachine';
+
+describe('declaration', () => {
+  describe('INT8', () => {
+    const smallestPossibleValue = -128;
+    const largestPossibleValue = 127;
+
+    test('underflows', () => {
+      const code = `
+          char main() {
+              char x = ${smallestPossibleValue - 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(largestPossibleValue);
+    });
+
+    test('overflows', () => {
+      const code = `
+          char main() {
+              char x = ${largestPossibleValue + 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(smallestPossibleValue);
+    });
+  });
+
+  describe('UINT8', () => {
+    const smallestPossibleValue = 0;
+    const largestPossibleValue = 255;
+
+    test('underflows', () => {
+      const code = `
+          unsigned char main() {
+              unsigned char x = ${smallestPossibleValue - 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(largestPossibleValue);
+    });
+
+    test('overflows', () => {
+      const code = `
+          unsigned char main() {
+              unsigned char x = ${largestPossibleValue + 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(smallestPossibleValue);
+    });
+  });
+
+  describe('INT16', () => {
+    const smallestPossibleValue = -32768;
+    const largestPossibleValue = 32767;
+
+    test('underflows', () => {
+      const code = `
+          short main() {
+              short x = ${smallestPossibleValue - 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(largestPossibleValue);
+    });
+
+    test('overflows', () => {
+      const code = `
+          short main() {
+              short x = ${largestPossibleValue + 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(smallestPossibleValue);
+    });
+  });
+
+  describe('UINT16', () => {
+    const smallestPossibleValue = 0;
+    const largestPossibleValue = 65535;
+
+    test('underflows', () => {
+      const code = `
+          unsigned short main() {
+              unsigned short x = ${smallestPossibleValue - 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(largestPossibleValue);
+    });
+
+    test('overflows', () => {
+      const code = `
+          unsigned short main() {
+              unsigned short x = ${largestPossibleValue + 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(smallestPossibleValue);
+    });
+  });
+
+  describe('INT32', () => {
+    const smallestPossibleValue = -2147483648;
+    const largestPossibleValue = 2147483647;
+
+    test('underflows', () => {
+      const code = `
+          int main() {
+              int x = ${smallestPossibleValue - 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(largestPossibleValue);
+    });
+
+    test('overflows', () => {
+      const code = `
+          int main() {
+              int x = ${largestPossibleValue + 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(smallestPossibleValue);
+    });
+  });
+
+  describe('UINT32', () => {
+    const smallestPossibleValue = 0;
+    const largestPossibleValue = 4294967295;
+
+    test('underflows', () => {
+      const code = `
+          unsigned int main() {
+              unsigned int x = ${smallestPossibleValue - 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(largestPossibleValue);
+    });
+
+    test('overflows', () => {
+      const code = `
+          unsigned int main() {
+              unsigned int x = ${largestPossibleValue + 1};
+              return x;
+          }
+      `;
+      const ast = parse(code);
+      const instructions = compileProgram(ast);
+      const result = interpret(instructions);
+      expect(result).toEqual(smallestPossibleValue);
+    });
+  });
+});

--- a/src/interpreter/__tests__/unaryExpression.ts
+++ b/src/interpreter/__tests__/unaryExpression.ts
@@ -71,35 +71,4 @@ describe('unary expression', () => {
     const result = interpret(instructions);
     expect(result).not.toEqual(FALSE_VALUE);
   });
-
-  test('handles unary & and * operation', () => {
-    const code = `
-        int main() {
-            int a = 10;
-            int address = &a;
-            return *address + 2;
-        }
-    `;
-    const ast = parse(code);
-    const instructions = compileProgram(ast);
-    const result = interpret(instructions);
-    const expectedResult = 12;
-    expect(result).toEqual(expectedResult);
-  });
-
-  test('handles pointers to pointers', () => {
-    const code = `
-        int main() {
-            int a = 10;
-            int *address = &a;
-            int **addressOfAddress = &address;
-            return **addressOfAddress + 2;
-        }
-    `;
-    const ast = parse(code);
-    const instructions = compileProgram(ast);
-    const result = interpret(instructions);
-    const expectedResult = 12;
-    expect(result).toEqual(expectedResult);
-  });
 });

--- a/src/interpreter/builtins.ts
+++ b/src/interpreter/builtins.ts
@@ -1,4 +1,5 @@
 import { type SymbolTableFrame } from './types/symbolTable';
+import { BUILTIN } from '../ast/types/dataTypes';
 
 export const BUILT_INS: Record<string, any> = {
   sqrt: (x: number) => Math.sqrt(x)
@@ -9,7 +10,8 @@ export const getBuiltInSymbols = (): SymbolTableFrame => {
     sqrt: {
       nameType: 'BuiltInFunction',
       name: 'sqrt',
-      numOfParams: 1
+      numOfParams: 1,
+      dataType: BUILTIN
     }
   };
 };

--- a/src/interpreter/compiler.ts
+++ b/src/interpreter/compiler.ts
@@ -101,7 +101,7 @@ import {
   addProgramSymbolTableEntries,
   getArraySymbolTableEntry,
   getFunctionSymbolTableEntry,
-  getNumOfEntriesInFrame,
+  getSizeOfFrameInBytes,
   getSymbolTableEntry,
   getSymbolTableEntryInFrame,
   isArraySymbolTableEntry,
@@ -194,14 +194,25 @@ const compilers: CompilerMapping = {
     } else {
       compile(node.right, instructions, symbolTable, labelFrame);
     }
-    let unaryAddressExpression;
     if (isUnaryExpression(node.left) && node.left.operator === '*') {
       // If assigning to a pointer, simply remove one layer of indirection.
-      unaryAddressExpression = node.left.operand;
+      // TODO: Figure this out properly.
+      if (!isIdentifier(node.left.operand)) {
+        throw new BrokenInvariantError();
+      }
+      const symbolTableEntry = getSymbolTableEntry(
+        node.left.operand.name,
+        symbolTable
+      );
+      if (isBuiltinFunctionSymbolTableEntry(symbolTableEntry)) {
+        throw new BrokenInvariantError();
+      }
+      const loadSymbolInstr = constructLoadSymbolInstr(symbolTableEntry, true);
+      instructions.push(loadSymbolInstr);
     } else {
-      unaryAddressExpression = constructUnaryAddressExpression(node.left);
+      const unaryAddressExpression = constructUnaryAddressExpression(node.left);
+      compile(unaryAddressExpression, instructions, symbolTable, labelFrame);
     }
-    compile(unaryAddressExpression, instructions, symbolTable, labelFrame);
     const assignToAddressInstr = constructAssignToAddressInstr();
     instructions.push(assignToAddressInstr);
   },
@@ -251,18 +262,17 @@ const compilers: CompilerMapping = {
       node.callee.name,
       symbolTable
     );
-    if (functionEntry.numOfParams !== node.arguments.length) {
-      throw new InvalidCallError(
-        `Function takes in ${functionEntry.numOfParams} arguments but ${node.arguments.length} arguments were passed in.`
-      );
-    }
-
     compile(node.callee, instructions, symbolTable, labelFrame);
-    node.arguments.forEach((arg) => {
-      compile(arg, instructions, symbolTable, labelFrame);
-    });
+    for (let i = node.arguments.length - 1; i >= 0; i--) {
+      compile(node.arguments[i], instructions, symbolTable, labelFrame);
+    }
     // If the function being called is a built-in function, we simply push the CallBuiltInInstr.
     if (isBuiltinFunctionSymbolTableEntry(functionEntry)) {
+      if (functionEntry.numOfParams !== node.arguments.length) {
+        throw new InvalidCallError(
+          `Function takes in ${functionEntry.numOfParams} arguments but ${node.arguments.length} arguments were passed in.`
+        );
+      }
       const callBuiltInInstr = constructCallBuiltInInstr(
         functionEntry.name,
         node.arguments.length
@@ -270,11 +280,22 @@ const compilers: CompilerMapping = {
       instructions.push(callBuiltInInstr);
       return;
     }
+
+    // Note: This would change if/when variadic functions are supported.
+    // - There can be less param data types than arguments.
+    // - More param symbol table entries must be inserted according to the number of args.
+    if (functionEntry.paramDataTypes.length !== node.arguments.length) {
+      throw new InvalidCallError(
+        `Function takes in ${functionEntry.paramDataTypes.length} arguments but ${node.arguments.length} arguments were passed in.`
+      );
+    }
+
     const loadReturnAddressInstr = constructLoadReturnAddressInstr();
     instructions.push(loadReturnAddressInstr);
     const callInstr = constructCallInstr(
       node.arguments.length,
-      functionEntry.numOfEntriesForVariables
+      functionEntry.paramDataTypes,
+      functionEntry.totalSizeOfVariablesInBytes
     );
     instructions.push(callInstr);
   },
@@ -457,9 +478,20 @@ const compilers: CompilerMapping = {
 
     loadFunctionInstr.functionInstrAddress = instructions.length;
 
+    const symbolTableEntry = getSymbolTableEntry(
+      getNameFromDeclaratorPattern(node.id),
+      symbolTable
+    );
+    if (!isUserDeclaredFunctionSymbolTableEntry(symbolTableEntry)) {
+      throw new BrokenInvariantError(
+        'Symbol table entry should always be for a user-declared function here.'
+      );
+    }
+
     const functionSymbolTable = addFunctionSymbolTableEntries(
       node,
-      symbolTable
+      symbolTable,
+      symbolTableEntry
     );
     const newLabelFrame = constructFunctionLabelFrame(node);
     if (!isEmptyStatement(node.body)) {
@@ -472,15 +504,6 @@ const compilers: CompilerMapping = {
 
     jumpInstr.instrAddress = instructions.length;
 
-    const symbolTableEntry = getSymbolTableEntry(
-      getNameFromDeclaratorPattern(node.id),
-      symbolTable
-    );
-    if (!isUserDeclaredFunctionSymbolTableEntry(symbolTableEntry)) {
-      throw new BrokenInvariantError(
-        'Symbol table entry should always be for a user-declared function here.'
-      );
-    }
     const assignInstr = constructAssignInstr(symbolTableEntry, 1);
     instructions.push(assignInstr);
   },
@@ -509,7 +532,7 @@ const compilers: CompilerMapping = {
     if (isBuiltinFunctionSymbolTableEntry(symbolTableEntry)) {
       return;
     }
-    const loadSymbolInstr = constructLoadSymbolInstr(symbolTableEntry);
+    const loadSymbolInstr = constructLoadSymbolInstr(symbolTableEntry, false);
     instructions.push(loadSymbolInstr);
   },
   IdentifierStatement: (
@@ -608,7 +631,7 @@ const compilers: CompilerMapping = {
   ) => {
     const programSymbolTable = addProgramSymbolTableEntries(node, symbolTable);
     const enterProgramInstr = constructEnterProgramInstr(
-      getNumOfEntriesInFrame(programSymbolTable.head)
+      getSizeOfFrameInBytes(symbolTable.head)
     );
     instructions.push(enterProgramInstr);
     node.body.forEach((item) => {

--- a/src/interpreter/compilerUtils.ts
+++ b/src/interpreter/compilerUtils.ts
@@ -28,28 +28,22 @@ export const getNameFromDeclaratorPattern = (
   throw new UnsupportedDeclarationError();
 };
 
-// TODO: This method may be modified once types are introduced.
-export const getFixedNumOfEntriesOfDeclaratorPattern = (
+export const getFixedNumOfItemsOfDeclaratorPattern = (
   pattern: DeclaratorPattern
 ): number => {
   if (isIdentifier(pattern)) {
-    // Allocate 1 entry space to each identifier for now.
     return 1;
   }
 
   if (isArrayPattern(pattern)) {
-    // Allocate 1 entry space to each item in the array for now.
-    // Multiply the sizes of each array dimension to get the total array size.
     return getArrayMaxNumOfItems(pattern);
   }
 
   if (isFunctionPattern(pattern)) {
-    // Function should point to an address. An address takes 1 entry space.
     return 1;
   }
 
   if (isPointerPattern(pattern)) {
-    // Pointer should point to an address. An address takes 1 entry space.
     return 1;
   }
 

--- a/src/interpreter/instructions.ts
+++ b/src/interpreter/instructions.ts
@@ -33,6 +33,10 @@ import {
 import { type SymbolTableEntryWithAddress } from './types/symbolTable';
 import { getSegmentScope } from './symbolTable';
 import { type Value } from './types/virtualMachine';
+import {
+  constructAddressDataType,
+  type DataType
+} from '../ast/types/dataTypes';
 
 export const PLACEHOLDER_ADDRESS = -1;
 
@@ -52,7 +56,8 @@ export const constructAssignInstr = (
   type: 'Assign',
   scope: getSegmentScope(entry.scope),
   offset: entry.offset,
-  numOfItems
+  numOfItems,
+  dataTypeOfEachItem: entry.dataType
 });
 
 export const constructAssignToAddressInstr = (): AssignToAddressInstr => ({
@@ -76,11 +81,13 @@ export const constructBreakDoneInstr = (): BreakDoneInstr => ({
 
 export const constructCallInstr = (
   numOfArgs: number,
-  numOfEntriesForVars: number
+  paramDataTypes: DataType[],
+  totalSizeOfVariablesInBytes: number
 ): CallInstr => ({
   type: 'Call',
   numOfArgs,
-  numOfEntriesForVars
+  paramDataTypes,
+  totalSizeOfVariablesInBytes
 });
 
 export const constructCallBuiltInInstr = (
@@ -105,10 +112,10 @@ export const constructDoneInstr = (): DoneInstr => ({
 });
 
 export const constructEnterProgramInstr = (
-  numOfDeclarations: number
+  sizeOfDeclarationsInBytes: number
 ): EnterProgramInstr => ({
   type: 'EnterProgram',
-  numOfDeclarations
+  sizeOfDeclarationsInBytes
 });
 
 export const constructFallthroughInstr = (): FallthroughInstr => ({
@@ -143,7 +150,8 @@ export const constructLoadAddressInstr = (
 ): LoadAddressInstr => ({
   type: 'LoadAddress',
   scope: getSegmentScope(entry.scope),
-  offset: entry.offset
+  offset: entry.offset,
+  dataType: constructAddressDataType(entry.dataType)
 });
 
 export const constructLoadConstantInstr = (
@@ -165,11 +173,15 @@ export const constructLoadReturnAddressInstr = (): LoadReturnAddressInstr => ({
 });
 
 export const constructLoadSymbolInstr = (
-  entry: SymbolTableEntryWithAddress
+  entry: SymbolTableEntryWithAddress,
+  forAddress: boolean
 ): LoadSymbolInstr => ({
   type: 'LoadSymbol',
   scope: getSegmentScope(entry.scope),
-  offset: entry.offset
+  offset: entry.offset,
+  dataType: forAddress
+    ? constructAddressDataType(entry.dataType)
+    : entry.dataType
 });
 
 export const constructMatchCaseInstr = (): MatchCaseInstr => ({

--- a/src/interpreter/symbolTable.ts
+++ b/src/interpreter/symbolTable.ts
@@ -28,24 +28,29 @@ import {
   isEmptyStatement,
   isForStatement,
   isParameterDeclaratorDeclaration,
-  isDeclaration
+  isDeclaration,
+  isPointerPattern
 } from '../ast/types/typeGuards';
 import { Segment } from '../memory/segment';
 import { isNotNull, isNotUndefined } from '../utils/typeGuards';
 import {
   getArrayMaxNumOfItems,
   getArrayPatternMultipliers,
-  getFixedNumOfEntriesOfDeclaratorPattern,
+  getFixedNumOfItemsOfDeclaratorPattern,
   getNameFromDeclaratorPattern
 } from './compilerUtils';
-import { BrokenInvariantError } from '../ast/errors';
+import {
+  ADDRESS_SIZE_IN_BYTES,
+  constructAddressDataType,
+  FLOAT64
+} from '../ast/types/dataTypes';
 
 export const addProgramSymbolTableEntries = (
   program: Program,
   symbolTable: SymbolTable
 ): SymbolTable => {
   const frame = symbolTable.head;
-  let offset = getNumOfEntriesInFrame(frame);
+  let offset = getSizeOfFrameInBytes(frame);
   program.body.forEach((declaration) => {
     switch (declaration.type) {
       case 'FunctionDeclaration': {
@@ -76,18 +81,21 @@ export const addProgramSymbolTableEntries = (
 
 export const addFunctionSymbolTableEntries = (
   node: FunctionDeclaration,
-  symbolTable: SymbolTable
+  symbolTable: SymbolTable,
+  functionEntry: UserDeclaredFunctionSymbolTableEntry
 ): SymbolTable => {
   const frame: SymbolTableFrame = {};
   // The parameters of the current stack frame can be found via an offset of -4
   // from the current rbp. See `stackFunctionCallSetup` for more information.
-  let offset = -4;
+  const paramsStartOffset = -3 * ADDRESS_SIZE_IN_BYTES;
+  let offset = paramsStartOffset;
   node.params.forEach((param) => {
     offset = addParameterDeclarationSymbolTableEntries(
       param,
       'Function',
       offset,
-      frame
+      frame,
+      functionEntry
     );
   });
 
@@ -112,17 +120,7 @@ export const addFunctionSymbolTableEntries = (
     });
   }
 
-  const functionEntry = getFunctionSymbolTableEntry(
-    getNameFromDeclaratorPattern(node.id),
-    symbolTable
-  );
-  if (!isUserDeclaredFunctionSymbolTableEntry(functionEntry)) {
-    throw new BrokenInvariantError(
-      'Symbol table entry should always be for a user-declared function here.'
-    );
-  }
-  functionEntry.numOfParams = node.params.length;
-  functionEntry.numOfEntriesForVariables += offset;
+  functionEntry.totalSizeOfVariablesInBytes = offset;
 
   return {
     head: frame,
@@ -139,7 +137,7 @@ export const addBlockSymbolTableEntries = (
   if (!isNotNull(symbolTable.parent)) {
     throw new InvalidScopeError('Block is not inside a function.');
   }
-  let offset = symbolTable.parent.numOfEntriesForVariables;
+  let offset = symbolTable.parent.totalSizeOfVariablesInBytes;
   block.items.forEach((item) => {
     const declaration = isDeclaration(item)
       ? item
@@ -158,7 +156,7 @@ export const addBlockSymbolTableEntries = (
     }
   });
 
-  symbolTable.parent.numOfEntriesForVariables = offset;
+  symbolTable.parent.totalSizeOfVariablesInBytes = offset;
 
   return {
     head: frame,
@@ -262,8 +260,11 @@ export const isVariableSymbolTableEntry = (
   return entry.nameType === 'Variable';
 };
 
-export const getNumOfEntriesInFrame = (frame: SymbolTableFrame): number => {
-  return Object.keys(frame).length;
+export const getSizeOfFrameInBytes = (frame: SymbolTableFrame): number => {
+  return Object.values(frame).reduce(
+    (total, currEntry) => (total += currEntry.dataType.sizeInBytes),
+    0
+  );
 };
 
 const addToFrame = (
@@ -289,11 +290,13 @@ const addFunctionDeclarationSymbolTableEntry = (
     nameType: 'UserDeclaredFunction',
     offset,
     scope,
-    // TODO: Update this when function declaration parameters are supported.
-    numOfParams: 0,
-    numOfEntriesForVariables: 0
+    paramDataTypes: [],
+    totalSizeOfVariablesInBytes: 0,
+    dataType: constructAddressDataType(FLOAT64)
   };
-  offset += getFixedNumOfEntriesOfDeclaratorPattern(functionDeclaration.id);
+  offset +=
+    getFixedNumOfItemsOfDeclaratorPattern(functionDeclaration.id) *
+    ADDRESS_SIZE_IN_BYTES;
   addToFrame(symbolTableFrame, entry);
   return offset;
 };
@@ -314,17 +317,36 @@ const addDeclarationSymbolTableEntries = (
         offset,
         scope,
         multipliers: getArrayPatternMultipliers(declarator.pattern),
-        maxNumOfItems: getArrayMaxNumOfItems(declarator.pattern)
+        maxNumOfItems: getArrayMaxNumOfItems(declarator.pattern),
+        dataType: declaration.dataType
       };
+      offset +=
+        getFixedNumOfItemsOfDeclaratorPattern(declarator.pattern) *
+        declaration.dataType.sizeInBytes;
+    } else if (isPointerPattern(declarator.pattern)) {
+      const dataType = constructAddressDataType(declaration.dataType);
+      entry = {
+        name: getNameFromDeclaratorPattern(declarator.pattern),
+        nameType: 'Variable',
+        offset,
+        scope,
+        dataType
+      };
+      offset +=
+        getFixedNumOfItemsOfDeclaratorPattern(declarator.pattern) *
+        dataType.sizeInBytes;
     } else {
       entry = {
         name: getNameFromDeclaratorPattern(declarator.pattern),
         nameType: 'Variable',
         offset,
-        scope
+        scope,
+        dataType: declaration.dataType
       };
+      offset +=
+        getFixedNumOfItemsOfDeclaratorPattern(declarator.pattern) *
+        declaration.dataType.sizeInBytes;
     }
-    offset += getFixedNumOfEntriesOfDeclaratorPattern(declarator.pattern);
     addToFrame(symbolTableFrame, entry);
   });
   return offset;
@@ -334,30 +356,54 @@ const addParameterDeclarationSymbolTableEntries = (
   parameterDeclaration: ParameterDeclaration,
   scope: SymbolTableEntryScope,
   startingOffset: number,
-  symbolTableFrame: SymbolTableFrame
+  symbolTableFrame: SymbolTableFrame,
+  functionEntry: UserDeclaredFunctionSymbolTableEntry
 ): number => {
   let offset = startingOffset;
   let entry: SymbolTableEntry;
   if (isParameterDeclaratorDeclaration(parameterDeclaration)) {
     const declaratorPattern = parameterDeclaration.declarator;
     if (isArrayPattern(declaratorPattern)) {
+      const dataType = constructAddressDataType(parameterDeclaration.dataType);
+      offset -=
+        getFixedNumOfItemsOfDeclaratorPattern(declaratorPattern) *
+        dataType.sizeInBytes;
+      functionEntry.paramDataTypes.push(dataType);
       entry = {
         name: getNameFromDeclaratorPattern(declaratorPattern),
         nameType: 'Array',
         offset,
         scope,
         multipliers: getArrayPatternMultipliers(declaratorPattern),
-        maxNumOfItems: getArrayMaxNumOfItems(declaratorPattern)
+        maxNumOfItems: getArrayMaxNumOfItems(declaratorPattern),
+        dataType
       };
-    } else {
+    } else if (isPointerPattern(declaratorPattern)) {
+      const dataType = constructAddressDataType(parameterDeclaration.dataType);
+      offset -=
+        getFixedNumOfItemsOfDeclaratorPattern(declaratorPattern) *
+        dataType.sizeInBytes;
+      functionEntry.paramDataTypes.push(dataType);
       entry = {
         name: getNameFromDeclaratorPattern(declaratorPattern),
         nameType: 'Variable',
         offset,
-        scope
+        scope,
+        dataType
+      };
+    } else {
+      offset -=
+        getFixedNumOfItemsOfDeclaratorPattern(declaratorPattern) *
+        parameterDeclaration.dataType.sizeInBytes;
+      functionEntry.paramDataTypes.push(parameterDeclaration.dataType);
+      entry = {
+        name: getNameFromDeclaratorPattern(declaratorPattern),
+        nameType: 'Variable',
+        offset,
+        scope,
+        dataType: parameterDeclaration.dataType
       };
     }
-    offset -= getFixedNumOfEntriesOfDeclaratorPattern(declaratorPattern);
   } else {
     // TODO: Handle ParameterAbstractDeclaratorDeclaration.
     throw new Error(

--- a/src/interpreter/types/instructions.ts
+++ b/src/interpreter/types/instructions.ts
@@ -1,5 +1,6 @@
 import { type Segment } from '../../memory/segment';
 import { type Value } from './virtualMachine';
+import { type DataType } from '../../ast/types/dataTypes';
 
 interface BaseInstr {
   type: string;
@@ -45,6 +46,7 @@ export interface AssignInstr extends BaseInstr {
   scope: Segment;
   offset: number;
   numOfItems: number;
+  dataTypeOfEachItem: DataType;
 }
 
 export interface AssignToAddressInstr extends BaseInstr {
@@ -67,7 +69,8 @@ export interface BreakDoneInstr extends BaseInstr {
 export interface CallInstr extends BaseInstr {
   type: 'Call';
   numOfArgs: number;
-  numOfEntriesForVars: number;
+  paramDataTypes: DataType[];
+  totalSizeOfVariablesInBytes: number;
 }
 
 export interface CallBuiltInInstr extends BaseInstr {
@@ -90,7 +93,7 @@ export interface DoneInstr extends BaseInstr {
 
 export interface EnterProgramInstr extends BaseInstr {
   type: 'EnterProgram';
-  numOfDeclarations: number;
+  sizeOfDeclarationsInBytes: number;
 }
 
 export interface FallthroughInstr extends BaseInstr {
@@ -120,6 +123,7 @@ export interface LoadAddressInstr extends BaseInstr {
   type: 'LoadAddress';
   scope: Segment;
   offset: number;
+  dataType: DataType;
 }
 
 export interface LoadConstantInstr extends BaseInstr {
@@ -140,6 +144,7 @@ export interface LoadSymbolInstr extends BaseInstr {
   type: 'LoadSymbol';
   scope: Segment;
   offset: number;
+  dataType: DataType;
 }
 
 export interface MatchCaseInstr extends BaseInstr {

--- a/src/interpreter/types/symbolTable.ts
+++ b/src/interpreter/types/symbolTable.ts
@@ -1,3 +1,5 @@
+import { type DataType } from '../../ast/types/dataTypes';
+
 export interface SymbolTable {
   head: SymbolTableFrame;
   tail: SymbolTable | null;
@@ -19,6 +21,7 @@ export interface BaseSymbolTableEntry {
   // make use of TypeScript's discriminated unions.
   nameType: string;
   name: string;
+  dataType: DataType;
 }
 
 export interface BaseSymbolTableEntryWithAddress extends BaseSymbolTableEntry {
@@ -35,8 +38,8 @@ export interface ArraySymbolTableEntry extends BaseSymbolTableEntryWithAddress {
 export interface UserDeclaredFunctionSymbolTableEntry
   extends BaseSymbolTableEntryWithAddress {
   nameType: 'UserDeclaredFunction';
-  numOfParams: number;
-  numOfEntriesForVariables: number;
+  paramDataTypes: DataType[];
+  totalSizeOfVariablesInBytes: number;
 }
 
 export interface BuiltInFunctionSymbolTableEntry extends BaseSymbolTableEntry {

--- a/src/interpreter/types/virtualMachine.ts
+++ b/src/interpreter/types/virtualMachine.ts
@@ -1,6 +1,7 @@
 import { type Instr } from './instructions';
 import { type Memory } from '../../memory/memory';
 import { type Stack } from '../../utils/stack';
+import { type DataType } from '../../ast/types/dataTypes';
 
 export type VirtualMachineMapping = {
   [InstrType in Instr['type']]: (
@@ -15,3 +16,8 @@ export interface VirtualMachineState {
 }
 
 export type Value = any;
+
+export interface ValueWithDataType {
+  value: Value;
+  dataType: DataType;
+}

--- a/src/memory/pageTable.ts
+++ b/src/memory/pageTable.ts
@@ -25,114 +25,164 @@ export class PageTable {
   }
 
   /**
-   * Gets the data from the entry at the offset.
-   * Note: This should be the offset to an entry (9 bits),
-   * not an offset to the within the entry (12 bits)
-   */
-  public get(offset: number): number {
-    if (!this.isValidOffset(offset)) {
-      throw new MemoryError(MemoryErrorType.INVALID_OFFSET, offset);
-    }
-
-    return this.memory.getFloat64(offset * PageTable.ENTRY_SIZE);
-  }
-
-  /**
-   * Sets the first free entry in the free list to contain data.
-   */
-  public setFreeEntry(data: number): number {
-    const offset = this.freeList;
-
-    if (!this.isValidOffset(offset)) {
-      throw new MemoryError(MemoryErrorType.INVALID_OFFSET, offset);
-    }
-
-    this.freeList = this.get(offset);
-    this.memory.setFloat64(offset * PageTable.ENTRY_SIZE, data);
-    return offset;
-  }
-
-  /**
    * Sets a free entry to contain data.
    */
-  public setFreeEntryAt(offset: number, data: number): number {
-    if (!this.isValidOffset(offset)) {
-      throw new MemoryError(MemoryErrorType.INVALID_OFFSET, offset);
+  public setFreeEntryAt(entryOffset: number, data: number): number {
+    if (!this.isValidEntryOffset(entryOffset)) {
+      throw new MemoryError(MemoryErrorType.INVALID_OFFSET, entryOffset);
     }
 
-    assert(this.isFree(offset), 'Offset must be free.');
+    assert(this.isFreeEntry(entryOffset), 'Offset must be free.');
 
-    this.removeFromFreeList(offset);
-    this.memory.setFloat64(offset * PageTable.ENTRY_SIZE, data);
-    return offset;
+    this.removeEntryFromFreeList(entryOffset);
+    this.memory.setFloat64(entryOffset * PageTable.ENTRY_SIZE, data);
+    return entryOffset;
   }
 
-  /**
-   * Updates the data contained in a used entry.
-   */
-  public setAllocatedEntry(offset: number, data: number): void {
-    if (!this.isValidOffset(offset)) {
-      throw new MemoryError(MemoryErrorType.INVALID_OFFSET, offset);
-    }
-
-    assert(!this.isFree(offset), 'Only allocated entries can be set.');
-
-    this.memory.setFloat64(offset * PageTable.ENTRY_SIZE, data);
+  public getInt8(offset: number): number {
+    return this.memory.getInt8(offset);
   }
 
-  /**
-   * Frees entry at offset.
-   */
-  public free(offset: number): void {
-    if (!this.isValidOffset(offset)) {
-      throw new MemoryError(MemoryErrorType.INVALID_OFFSET, offset);
-    }
-
-    assert(!this.isFree(offset), 'Only allocated entries can be freed.');
-
-    this.memory.setFloat64(offset * PageTable.ENTRY_SIZE, this.freeList);
-    this.freeList = offset;
+  public getUint8(offset: number): number {
+    return this.memory.getUint8(offset);
   }
 
-  private removeFromFreeList(offset: number): void {
-    let prevFreeOffset = PageTable.EMPTY_FREE_LIST;
-    let freeOffset = this.freeList;
-    while (freeOffset !== offset && freeOffset !== PageTable.EMPTY_FREE_LIST) {
-      prevFreeOffset = freeOffset;
-      freeOffset = this.get(freeOffset);
+  public getInt16(offset: number): number {
+    return this.memory.getInt16(offset);
+  }
+
+  public getUint16(offset: number): number {
+    return this.memory.getUint16(offset);
+  }
+
+  public getInt32(offset: number): number {
+    return this.memory.getInt32(offset);
+  }
+
+  public getUint32(offset: number): number {
+    return this.memory.getUint32(offset);
+  }
+
+  public getInt64(offset: number): bigint {
+    return this.memory.getBigInt64(offset);
+  }
+
+  public getUint64(offset: number): bigint {
+    return this.memory.getBigUint64(offset);
+  }
+
+  public getFloat32(offset: number): number {
+    return this.memory.getFloat32(offset);
+  }
+
+  public getFloat64(offset: number): number {
+    return this.memory.getFloat64(offset);
+  }
+
+  public setInt8(offset: number, data: number): void {
+    this.memory.setInt8(offset, data);
+  }
+
+  public setUint8(offset: number, data: number): void {
+    this.memory.setUint8(offset, data);
+  }
+
+  public setInt16(offset: number, data: number): void {
+    this.memory.setInt16(offset, data);
+  }
+
+  public setUint16(offset: number, data: number): void {
+    this.memory.setUint16(offset, data);
+  }
+
+  public setInt32(offset: number, data: number): void {
+    this.memory.setInt32(offset, data);
+  }
+
+  public setUint32(offset: number, data: number): void {
+    this.memory.setUint32(offset, data);
+  }
+
+  public setInt64(offset: number, data: bigint): void {
+    this.memory.setBigInt64(offset, data);
+  }
+
+  public setUint64(offset: number, data: bigint): void {
+    this.memory.setBigUint64(offset, data);
+  }
+
+  public setFloat32(offset: number, data: number): void {
+    this.memory.setFloat32(offset, data);
+  }
+
+  public setFloat64(offset: number, data: number): void {
+    this.memory.setFloat64(offset, data);
+  }
+
+  public freeEntry(entryOffset: number): void {
+    if (!this.isValidEntryOffset(entryOffset)) {
+      throw new MemoryError(MemoryErrorType.INVALID_OFFSET, entryOffset);
     }
 
-    if (freeOffset === PageTable.EMPTY_FREE_LIST) {
+    assert(
+      !this.isFreeEntry(entryOffset),
+      'Only allocated entries can be freed.'
+    );
+
+    this.memory.setFloat64(entryOffset * PageTable.ENTRY_SIZE, this.freeList);
+    this.freeList = entryOffset;
+  }
+
+  private removeEntryFromFreeList(entryOffset: number): void {
+    let prevFreeEntryOffset = PageTable.EMPTY_FREE_LIST;
+    let freeEntryOffset = this.freeList;
+    while (
+      freeEntryOffset !== entryOffset &&
+      freeEntryOffset !== PageTable.EMPTY_FREE_LIST
+    ) {
+      prevFreeEntryOffset = freeEntryOffset;
+      freeEntryOffset = this.memory.getFloat64(
+        freeEntryOffset * PageTable.ENTRY_SIZE
+      );
+    }
+
+    if (freeEntryOffset === PageTable.EMPTY_FREE_LIST) {
       return;
     }
 
-    if (prevFreeOffset === PageTable.EMPTY_FREE_LIST) {
-      this.freeList = this.get(freeOffset);
+    if (prevFreeEntryOffset === PageTable.EMPTY_FREE_LIST) {
+      this.freeList = this.memory.getFloat64(
+        freeEntryOffset * PageTable.ENTRY_SIZE
+      );
     }
 
-    if (prevFreeOffset !== PageTable.EMPTY_FREE_LIST) {
+    if (prevFreeEntryOffset !== PageTable.EMPTY_FREE_LIST) {
       this.memory.setFloat64(
-        prevFreeOffset * PageTable.ENTRY_SIZE,
-        this.get(freeOffset)
+        prevFreeEntryOffset * PageTable.ENTRY_SIZE,
+        this.memory.getFloat64(freeEntryOffset * PageTable.ENTRY_SIZE)
       );
     }
   }
 
-  private isValidOffset(offset: number): boolean {
-    return this.isWithinBounds(offset) && Number.isInteger(offset);
+  private isValidEntryOffset(entryOffset: number): boolean {
+    return (
+      this.entryIsWithinBounds(entryOffset) && Number.isInteger(entryOffset)
+    );
   }
 
-  private isWithinBounds(offset: number): boolean {
-    return offset >= 0 && offset <= PageTable.NUM_OF_ENTRIES - 1;
+  private entryIsWithinBounds(entryOffset: number): boolean {
+    return entryOffset >= 0 && entryOffset <= PageTable.NUM_OF_ENTRIES - 1;
   }
 
-  private isFree(offset: number): boolean {
-    let freeOffset = this.freeList;
-    while (freeOffset !== PageTable.EMPTY_FREE_LIST) {
-      if (offset === freeOffset) {
+  private isFreeEntry(entryOffset: number): boolean {
+    let freeEntryOffset = this.freeList;
+    while (freeEntryOffset !== PageTable.EMPTY_FREE_LIST) {
+      if (entryOffset === freeEntryOffset) {
         return true;
       }
-      freeOffset = this.get(freeOffset);
+      freeEntryOffset = this.memory.getFloat64(
+        freeEntryOffset * PageTable.ENTRY_SIZE
+      );
     }
     return false;
   }

--- a/src/memory/virtualMemory.ts
+++ b/src/memory/virtualMemory.ts
@@ -2,10 +2,7 @@ import { PageTable } from './pageTable';
 import { AddressIndex } from './addressIndex';
 import { Segment } from './segment';
 import { SegmentAddress } from './segmentAddress';
-import {
-  type Value,
-  type ValueWithDataType
-} from '../interpreter/types/virtualMachine';
+import { type ValueWithDataType } from '../interpreter/types/virtualMachine';
 import {
   ADDRESS_SIZE_IN_BYTES,
   constructAddressDataType,
@@ -203,7 +200,7 @@ export class VirtualMemory {
     return baseAddress + offset;
   }
 
-  public get(address: number, dataType: DataType): Value {
+  public get(address: number, dataType: DataType): number {
     const addressIndex = AddressIndex.fromAddress(address);
     const l5PageTable = this.getL5PageTable(addressIndex);
     const offset = addressIndex.l5Idx;
@@ -218,7 +215,8 @@ export class VirtualMemory {
             case 4:
               return l5PageTable.getInt32(offset);
             case 8:
-              return l5PageTable.getInt64(offset);
+              // FIXME: Only up to 53-bit integers are supported.
+              return Number(l5PageTable.getInt64(offset));
             default:
               throw new TypeError(
                 `Tried to get an invalid Int size in the memory: ${dataType.sizeInBytes}`
@@ -233,7 +231,8 @@ export class VirtualMemory {
             case 4:
               return l5PageTable.getUint32(offset);
             case 8:
-              return l5PageTable.getUint64(offset);
+              // FIXME: Only up to 53-bit integers are supported.
+              return Number(l5PageTable.getUint64(offset));
             default:
               throw new TypeError(
                 `Tried to get an invalid Uint size in the memory: ${dataType.sizeInBytes}`
@@ -273,7 +272,7 @@ export class VirtualMemory {
     l5PageTable.setFreeEntryAt(addressIndex.getL5EntryOffset(), data);
   }
 
-  public set(address: number, value: Value, dataType: DataType): void {
+  public set(address: number, value: number, dataType: DataType): void {
     const addressIndex = AddressIndex.fromAddress(address);
     const l5PageTable = this.getL5PageTable(addressIndex);
     const offset = addressIndex.l5Idx;
@@ -291,7 +290,7 @@ export class VirtualMemory {
               l5PageTable.setInt32(offset, value);
               break;
             case 8:
-              l5PageTable.setInt64(offset, value);
+              l5PageTable.setInt64(offset, BigInt(value));
               break;
             default:
               throw new TypeError(
@@ -310,7 +309,7 @@ export class VirtualMemory {
               l5PageTable.setUint32(offset, value);
               break;
             case 8:
-              l5PageTable.setUint64(offset, value);
+              l5PageTable.setUint64(offset, BigInt(value));
               break;
             default:
               throw new TypeError(

--- a/src/parser/__tests__/declarations/abstractDeclarator.ts
+++ b/src/parser/__tests__/declarations/abstractDeclarator.ts
@@ -1,6 +1,6 @@
 import { parse } from '../../parser';
 import { type Program, StaticStatus } from '../../../ast/types/ast';
-import { VOID } from '../../../ast/types/dataTypes';
+import { INT32, VOID } from '../../../ast/types/dataTypes';
 
 describe('abstract declarator', () => {
   test('bracket with no expression', () => {
@@ -25,6 +25,7 @@ describe('abstract declarator', () => {
                 params: [
                   {
                     type: 'ParameterAbstractDeclaratorDeclaration',
+                    dataType: INT32,
                     declarator: {
                       type: 'ExpressionlessBracketContent'
                     }
@@ -61,6 +62,7 @@ describe('abstract declarator', () => {
                 params: [
                   {
                     type: 'ParameterAbstractDeclaratorDeclaration',
+                    dataType: INT32,
                     declarator: {
                       type: 'ExpressionBracketContent',
                       expression: {


### PR DESCRIPTION
I removed the double pointers tests because the way we do pointers isn't right. For single pointers I did a hacky fix :( due to time constraints.

I'm not sure if you really want to use this, it needs a lot more refactoring for better code quality. But the idea should be correct.

The main idea is
- During compilation, every symbol table entry has a dataType. Since dataType affects the size allocated, get and set, everything that can be stored in the memory needs a dataType. This is also related to why we need to handle pointers properly (distinguish between pointers and variables).
- Memory is still allocated by entries. Just take Math.ceil(totalSizeInBytes / ENTRY_SIZE).
- Offsets are in terms of bytes. In the memory, since I didn't have enough brain cells to handle the changes, I just renamed offsets for entries to `entryOffset`.
- Get and Set is the same as what you did, it makes use of `dataType` to get and set the correct size.
- An `AddressDataType` carries both information on its own size (aka an address is 8 bytes), but it also carries information on the dataType of its value.

Things to reconsider
- Whether to lump AddressDataType and BuiltinDataType with the ast dataType. Either way, some form of AddressDataType is needed to handle memory operations involving getting and setting values that are addresses.
- For AddressDataType whose values are also addresses, it would be better to use a specific ADDRESS64 type or something instead of FLOAT64.
- Having to check if a stash value is a `ValueWithDataType` is pretty confusing. But I think it's necessary in some form or another because our stash doesn't carry data type info but we need it.
- Naming needs work :"(